### PR TITLE
Fix typehint and schedule ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 12 * * *"
 
 jobs:
   check:

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -71,6 +71,8 @@ type Field struct {
 	Name string `json:"name"`
 	// Type is the datatype of the field.
 	Type string `json:"type"`
+	// TypeHint is a hint regarding the datatype of the field.
+	TypeHint string `json:"typeHint"`
 }
 
 // DatasetInfo represents the details of the information stored inside an Axiom

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -389,23 +389,28 @@ func TestDatasetsService_Info(t *testing.T) {
 			"fields": [
 				{
 					"name": "_sysTime",
-					"type": "integer"
+					"type": "integer",
+            		"typeHint": ""
 				},
 				{
 					"name": "_time",
-					"type": "integer"
+					"type": "integer",
+            		"typeHint": ""
 				},
 				{
 					"name": "path",
-					"type": "string"
+					"type": "string",
+            		"typeHint": ""
 				},
 				{
 					"name": "size",
-					"type": "integer"
+					"type": "integer",
+            		"typeHint": ""
 				},
 				{
 					"name": "status",
-					"type": "integer"
+					"type": "integer",
+					"typeHint": ""
 				}
 			],
 			"created": "2020-11-18T21:30:20.623322799Z"


### PR DESCRIPTION
This PR does two things:

1. It adds a missing field. This was detected by the CI run of PR #10.
2. It puts CI on a schedule (once a day) so we detect those kinds of issues even if no PRs are pending.