### PR TITLE
Handle ingest-only token for non-ingest endpoints

### DIFF
--- a/axiom/axiom.go
+++ b/axiom/axiom.go
@@ -1,0 +1,15 @@
+package axiom
+
+import "strings"
+
+// IsIngestToken returns true if the given acces token is an ingest token. If
+// false is returned, that does not imply that the token is a personal token.
+func IsIngestToken(token string) bool {
+	return strings.HasPrefix(token, "xait-")
+}
+
+// IsPersonalToken returns true if the given acces token is a personal token.
+// If false is returned, that does not imply that the token is an ingest token.
+func IsPersonalToken(token string) bool {
+	return strings.HasPrefix(token, "xapt-")
+}

--- a/axiom/axiom_test.go
+++ b/axiom/axiom_test.go
@@ -1,0 +1,28 @@
+package axiom_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/axiomhq/axiom-go/axiom"
+)
+
+//nolint:gosec // Chill bro, those are just for testing.
+const (
+	ingestTokenStr      = "xait-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+	personalTokenStr    = "xapt-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+	unspecifiedTokenStr = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+)
+
+func TestIsIngestToken(t *testing.T) {
+	assert.True(t, axiom.IsIngestToken(ingestTokenStr))
+	assert.False(t, axiom.IsIngestToken(personalTokenStr))
+	assert.False(t, axiom.IsIngestToken(unspecifiedTokenStr))
+}
+
+func TestIsPersonalToken(t *testing.T) {
+	assert.True(t, axiom.IsPersonalToken(personalTokenStr))
+	assert.False(t, axiom.IsPersonalToken(ingestTokenStr))
+	assert.False(t, axiom.IsPersonalToken(unspecifiedTokenStr))
+}

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -25,6 +26,8 @@ var (
 	// endpoint with an ingest-only token configured.
 	ErrUnprivilegedToken = errors.New("using ingest token for non-ingest operation")
 )
+
+var ingestPathRe = regexp.MustCompile("^/api/v1/datasets/.+/ingest$")
 
 // Error is the generic error response returned on non 2xx HTTP status codes.
 // Either one of the two fields is populated. However, calling the Error()
@@ -213,7 +216,7 @@ func (c *Client) call(ctx context.Context, method, path string, body, v interfac
 // body will be included as the request body. If it isn't an io.Reader, it will
 // be included as a JSON encoded request body.
 func (c *Client) newRequest(ctx context.Context, method, path string, body interface{}) (*http.Request, error) {
-	if IsIngestToken(c.accessToken) && path != "/api/v1/tokens/ingest" {
+	if IsIngestToken(c.accessToken) && !ingestPathRe.MatchString(path) {
 		return nil, ErrUnprivilegedToken
 	}
 

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -27,7 +27,7 @@ var (
 	ErrUnprivilegedToken = errors.New("using ingest token for non-ingest operation")
 )
 
-var ingestPathRe = regexp.MustCompile("^/api/v1/datasets/.+/ingest$")
+var validIngestTokenPathRe = regexp.MustCompile("^/api/v1/(datasets/.+/ingest|tokens/ingest/validate)$")
 
 // Error is the generic error response returned on non 2xx HTTP status codes.
 // Either one of the two fields is populated. However, calling the Error()
@@ -216,7 +216,7 @@ func (c *Client) call(ctx context.Context, method, path string, body, v interfac
 // body will be included as the request body. If it isn't an io.Reader, it will
 // be included as a JSON encoded request body.
 func (c *Client) newRequest(ctx context.Context, method, path string, body interface{}) (*http.Request, error) {
-	if IsIngestToken(c.accessToken) && !ingestPathRe.MatchString(path) {
+	if IsIngestToken(c.accessToken) && !validIngestTokenPathRe.MatchString(path) {
 		return nil, ErrUnprivilegedToken
 	}
 

--- a/axiom/client_test.go
+++ b/axiom/client_test.go
@@ -214,6 +214,17 @@ func TestClient_do_Unauthenticated(t *testing.T) {
 	require.Equal(t, err, ErrUnauthenticated)
 }
 
+func TestClient_do_UnprivilegedToken(t *testing.T) {
+	client, teardown := setup(t, "/", nil)
+	defer teardown()
+
+	err := client.Options(SetAccessToken("xait-123"))
+	require.NoError(t, err)
+
+	_, err = client.newRequest(context.Background(), http.MethodGet, "/", nil)
+	require.Equal(t, err, ErrUnprivilegedToken)
+}
+
 func TestClient_do_RedirectLoop(t *testing.T) {
 	hf := func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusFound)

--- a/axiom/users_integration_test.go
+++ b/axiom/users_integration_test.go
@@ -40,7 +40,9 @@ func (s *UsersTestSuite) SetupSuite() {
 func (s *UsersTestSuite) TearDownSuite() {
 	// Teardown routines use their own context to avoid not being run at all
 	// when the suite gets cancelled or times out.
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	// HINT(lukasmalkmus): Sometimes, deleting a user can take very long under
+	// special circumstances. Account for that.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	err := s.client.Users.Delete(ctx, s.user.ID)


### PR DESCRIPTION
* Returns an error, if an ingest-only token is used for non-ingest operations
* Adds two new, public helper methods for identifying tokens
* Adds a new client option for setting the access token.