### PR TITLE
Drop VirtualField Alias field

### DIFF
--- a/axiom/client_integration_test.go
+++ b/axiom/client_integration_test.go
@@ -56,6 +56,10 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 	s.newClient()
 
+	if datasetSuffix == "" {
+		datasetSuffix = "local"
+	}
+
 	if strictDecoding {
 		err := s.client.Options(axiom.SetStrictDecoding())
 		s.Require().NoError(err)

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -74,10 +74,14 @@ type Dataset struct {
 type Field struct {
 	// Name is the unique name of the field.
 	Name string `json:"name"`
+	// Description is the description of the field.
+	Description string `json:"description"`
 	// Type is the datatype of the field.
 	Type string `json:"type"`
-	// TypeHint is a hint regarding the datatype of the field.
-	TypeHint string `json:"typeHint"`
+	// Unit is the unit of the field.
+	Unit string `json:"unit"`
+	// Hidden describes if the field is hidden or not.
+	Hidden bool `json:"hidden"`
 }
 
 // DatasetInfo represents the details of the information stored inside an Axiom
@@ -107,8 +111,10 @@ type DatasetInfo struct {
 	MaxTime time.Time `json:"maxTime"`
 	// Fields are the fields of the dataset.
 	Fields []Field `json:"fields"`
-	// Created is the time the dataset was created at.
-	Created time.Time `json:"created"`
+	// CreatedBy is the ID of the user who created the dataset.
+	CreatedBy string `json:"who"`
+	// CreatedAt is the time the dataset was created.
+	CreatedAt time.Time `json:"created"`
 }
 
 // DatasetStats are the stats of
@@ -148,8 +154,8 @@ type HistoryQuery struct {
 	Owner string `json:"who"`
 	// Query is the actual query.
 	Query query.Query `json:"query"`
-	// Created is the time the starred query was created at.
-	Created time.Time `json:"created"`
+	// CreatedAt is the time the history query was created.
+	CreatedAt time.Time `json:"created"`
 }
 
 // IngestStatus is the status after an event ingestion operation.

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -33,27 +33,43 @@ func TestDatasetsService_Stats(t *testing.T) {
 				MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
 				Fields: []Field{
 					{
-						Name: "_sysTime",
-						Type: "integer",
+						Name:        "_sysTime",
+						Description: "",
+						Type:        "integer",
+						Unit:        "",
+						Hidden:      false,
 					},
 					{
-						Name: "_time",
-						Type: "integer",
+						Name:        "_time",
+						Description: "",
+						Type:        "integer",
+						Unit:        "",
+						Hidden:      false,
 					},
 					{
-						Name: "path",
-						Type: "string",
+						Name:        "path",
+						Description: "",
+						Type:        "string",
+						Unit:        "",
+						Hidden:      false,
 					},
 					{
-						Name: "size",
-						Type: "integer",
+						Name:        "size",
+						Description: "",
+						Type:        "integer",
+						Unit:        "",
+						Hidden:      false,
 					},
 					{
-						Name: "status",
-						Type: "integer",
+						Name:        "status",
+						Description: "",
+						Type:        "integer",
+						Unit:        "",
+						Hidden:      false,
 					},
 				},
-				Created: mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
+				CreatedBy: "f83e245a-afdc-47ad-a765-4addd1994321",
+				CreatedAt: mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
 			},
 			{
 				Name:                 "test1",
@@ -68,27 +84,43 @@ func TestDatasetsService_Stats(t *testing.T) {
 				MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
 				Fields: []Field{
 					{
-						Name: "_sysTime",
-						Type: "integer",
+						Name:        "_sysTime",
+						Description: "",
+						Type:        "integer",
+						Unit:        "",
+						Hidden:      false,
 					},
 					{
-						Name: "_time",
-						Type: "integer",
+						Name:        "_time",
+						Description: "",
+						Type:        "integer",
+						Unit:        "",
+						Hidden:      false,
 					},
 					{
-						Name: "path",
-						Type: "string",
+						Name:        "path",
+						Description: "",
+						Type:        "string",
+						Unit:        "",
+						Hidden:      false,
 					},
 					{
-						Name: "size",
-						Type: "integer",
+						Name:        "size",
+						Description: "",
+						Type:        "integer",
+						Unit:        "",
+						Hidden:      false,
 					},
 					{
-						Name: "status",
-						Type: "integer",
+						Name:        "status",
+						Description: "",
+						Type:        "integer",
+						Unit:        "",
+						Hidden:      false,
 					},
 				},
-				Created: mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
+				CreatedBy: "f83e245a-afdc-47ad-a765-4addd1994321",
+				CreatedAt: mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
 			},
 		},
 		NumBlocks:            2,
@@ -118,25 +150,41 @@ func TestDatasetsService_Stats(t *testing.T) {
 					"fields": [
 						{
 							"name": "_sysTime",
-							"type": "integer"
+							"type": "integer",
+							"unit": "",
+            				"hidden": false,
+            				"description": ""
 						},
 						{
 							"name": "_time",
-							"type": "integer"
+							"type": "integer",
+							"unit": "",
+            				"hidden": false,
+            				"description": ""
 						},
 						{
 							"name": "path",
-							"type": "string"
+							"type": "string",
+							"unit": "",
+            				"hidden": false,
+            				"description": ""
 						},
 						{
 							"name": "size",
-							"type": "integer"
+							"type": "integer",
+							"unit": "",
+            				"hidden": false,
+            				"description": ""
 						},
 						{
 							"name": "status",
-							"type": "integer"
+							"type": "integer",
+							"unit": "",
+            				"hidden": false,
+            				"description": ""
 						}
 					],
+					"who": "f83e245a-afdc-47ad-a765-4addd1994321",
 					"created": "2020-11-18T21:30:20.623322799Z"
 				},
 				{
@@ -153,25 +201,41 @@ func TestDatasetsService_Stats(t *testing.T) {
 					"fields": [
 						{
 							"name": "_sysTime",
-							"type": "integer"
+							"type": "integer",
+							"unit": "",
+            				"hidden": false,
+            				"description": ""
 						},
 						{
 							"name": "_time",
-							"type": "integer"
+							"type": "integer",
+							"unit": "",
+            				"hidden": false,
+            				"description": ""
 						},
 						{
 							"name": "path",
-							"type": "string"
+							"type": "string",
+							"unit": "",
+            				"hidden": false,
+            				"description": ""
 						},
 						{
 							"name": "size",
-							"type": "integer"
+							"type": "integer",
+							"unit": "",
+            				"hidden": false,
+            				"description": ""
 						},
 						{
 							"name": "status",
-							"type": "integer"
+							"type": "integer",
+							"unit": "",
+            				"hidden": false,
+            				"description": ""
 						}
 					],
+					"who": "f83e245a-afdc-47ad-a765-4addd1994321",
 					"created": "2020-11-18T21:30:20.623322799Z"
 				}
 			],
@@ -356,27 +420,43 @@ func TestDatasetsService_Info(t *testing.T) {
 		MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
 		Fields: []Field{
 			{
-				Name: "_sysTime",
-				Type: "integer",
+				Name:        "_sysTime",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
 			},
 			{
-				Name: "_time",
-				Type: "integer",
+				Name:        "_time",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
 			},
 			{
-				Name: "path",
-				Type: "string",
+				Name:        "path",
+				Description: "",
+				Type:        "string",
+				Unit:        "",
+				Hidden:      false,
 			},
 			{
-				Name: "size",
-				Type: "integer",
+				Name:        "size",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
 			},
 			{
-				Name: "status",
-				Type: "integer",
+				Name:        "status",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
 			},
 		},
-		Created: mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
+		CreatedBy: "f83e245a-afdc-47ad-a765-4addd1994321",
+		CreatedAt: mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {
@@ -397,29 +477,40 @@ func TestDatasetsService_Info(t *testing.T) {
 				{
 					"name": "_sysTime",
 					"type": "integer",
-            		"typeHint": ""
+            		"unit": "",
+            		"hidden": false,
+            		"description": ""
 				},
 				{
 					"name": "_time",
 					"type": "integer",
-            		"typeHint": ""
+            		"unit": "",
+            		"hidden": false,
+            		"description": ""
 				},
 				{
 					"name": "path",
 					"type": "string",
-            		"typeHint": ""
+            		"unit": "",
+            		"hidden": false,
+            		"description": ""
 				},
 				{
 					"name": "size",
 					"type": "integer",
-            		"typeHint": ""
+            		"unit": "",
+            		"hidden": false,
+            		"description": ""
 				},
 				{
 					"name": "status",
 					"type": "integer",
-					"typeHint": ""
+					"unit": "",
+            		"hidden": false,
+            		"description": ""
 				}
 			],
+			"who": "f83e245a-afdc-47ad-a765-4addd1994321",
 			"created": "2020-11-18T21:30:20.623322799Z"
 		}`)
 		assert.NoError(t, err)
@@ -468,7 +559,7 @@ func TestDatasetsService_History(t *testing.T) {
 			EndTime:   mustTimeParse(t, time.RFC3339, "2020-11-25T14:00:00.000Z"),
 			Limit:     100,
 		},
-		Created: mustTimeParse(t, time.RFC3339, "2020-12-08T13:28:52.78954814Z"),
+		CreatedAt: mustTimeParse(t, time.RFC3339, "2020-12-08T13:28:52.78954814Z"),
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {

--- a/axiom/doc.go
+++ b/axiom/doc.go
@@ -13,7 +13,7 @@
 //
 //	client, err := axiom.NewClient("https://my-axiom.example.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
 //
-// 	Get the version of the configured deployment:
+// Get the version of the configured deployment:
 //	version, err := client.Version.Get(ctx)
 //
 // Some API methods have additional parameters that can be passed:

--- a/axiom/notifiers.go
+++ b/axiom/notifiers.go
@@ -64,10 +64,10 @@ type Notifier struct {
 	Properties interface{} `json:"properties"`
 	// DisabledUntil is the time until the notifier is being executed again.
 	DisabledUntil time.Time `json:"disabledUntil"`
-	// Created is the time the notifer was created at.
-	Created time.Time `json:"metaCreated"`
-	// Modified is the time the notifer was updated at.
-	Modified time.Time `json:"metaModified"`
+	// CreatedAt is the time the notifer was created.
+	CreatedAt time.Time `json:"metaCreated"`
+	// ModifiedAt is the time the notifer was last modified.
+	ModifiedAt time.Time `json:"metaModified"`
 	// Version of the notifier.
 	Version int64 `json:"metaVersion"`
 }

--- a/axiom/notifiers_test.go
+++ b/axiom/notifiers_test.go
@@ -26,9 +26,9 @@ func TestNotifiersService_List(t *testing.T) {
 					"c6c7381b-b24d-4107-b82e-d6cd26a490a1",
 				},
 			},
-			Created:  mustTimeParse(t, time.RFC3339, "2020-12-01T21:59:32.584410925Z"),
-			Modified: mustTimeParse(t, time.RFC3339, "2020-12-01T21:59:32.584410925Z"),
-			Version:  1606859972584410925,
+			CreatedAt:  mustTimeParse(t, time.RFC3339, "2020-12-01T21:59:32.584410925Z"),
+			ModifiedAt: mustTimeParse(t, time.RFC3339, "2020-12-01T21:59:32.584410925Z"),
+			Version:    1606859972584410925,
 		},
 		{
 			ID:   "d5I2Yv3Pg2Jx9Ne2Ay",
@@ -39,9 +39,9 @@ func TestNotifiersService_List(t *testing.T) {
 					"752e2388-8f6d-467a-88cc-cfba5ec407f4",
 				},
 			},
-			Created:  mustTimeParse(t, time.RFC3339, "2020-12-02T08:35:57.537528976Z"),
-			Modified: mustTimeParse(t, time.RFC3339, "2020-12-02T08:35:57.537528976Z"),
-			Version:  1606898157537528976,
+			CreatedAt:  mustTimeParse(t, time.RFC3339, "2020-12-02T08:35:57.537528976Z"),
+			ModifiedAt: mustTimeParse(t, time.RFC3339, "2020-12-02T08:35:57.537528976Z"),
+			Version:    1606898157537528976,
 		},
 	}
 
@@ -106,9 +106,9 @@ func TestNotifiersService_Get(t *testing.T) {
 				"c6c7381b-b24d-4107-b82e-d6cd26a490a1",
 			},
 		},
-		Created:  mustTimeParse(t, time.RFC3339, "2020-12-01T21:59:32.584410925Z"),
-		Modified: mustTimeParse(t, time.RFC3339, "2020-12-01T21:59:32.584410925Z"),
-		Version:  1606859972584410925,
+		CreatedAt:  mustTimeParse(t, time.RFC3339, "2020-12-01T21:59:32.584410925Z"),
+		ModifiedAt: mustTimeParse(t, time.RFC3339, "2020-12-01T21:59:32.584410925Z"),
+		Version:    1606859972584410925,
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {
@@ -145,12 +145,12 @@ func TestNotifiersService_Get(t *testing.T) {
 
 func TestNotifiersService_Create(t *testing.T) {
 	exp := &Notifier{
-		ID:       "ByiW67mUsS9FqZu0K0",
-		Name:     "Test",
-		Type:     Pagerduty,
-		Created:  mustTimeParse(t, time.RFC3339, "2020-12-03T16:42:07.326658202Z"),
-		Modified: mustTimeParse(t, time.RFC3339, "2020-12-03T16:42:07.326658202Z"),
-		Version:  1607013727326658202,
+		ID:         "ByiW67mUsS9FqZu0K0",
+		Name:       "Test",
+		Type:       Pagerduty,
+		CreatedAt:  mustTimeParse(t, time.RFC3339, "2020-12-03T16:42:07.326658202Z"),
+		ModifiedAt: mustTimeParse(t, time.RFC3339, "2020-12-03T16:42:07.326658202Z"),
+		Version:    1607013727326658202,
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {
@@ -184,12 +184,12 @@ func TestNotifiersService_Create(t *testing.T) {
 
 func TestNotifiersService_Update(t *testing.T) {
 	exp := &Notifier{
-		ID:       "ByiW67mUsS9FqZu0K0",
-		Name:     "Test",
-		Type:     Webhook,
-		Created:  mustTimeParse(t, time.RFC3339, "2020-12-03T16:42:07.326658202Z"),
-		Modified: mustTimeParse(t, time.RFC3339, "2020-12-03T16:42:07.326658202Z"),
-		Version:  1607013727326658202,
+		ID:         "ByiW67mUsS9FqZu0K0",
+		Name:       "Test",
+		Type:       Webhook,
+		CreatedAt:  mustTimeParse(t, time.RFC3339, "2020-12-03T16:42:07.326658202Z"),
+		ModifiedAt: mustTimeParse(t, time.RFC3339, "2020-12-03T16:42:07.326658202Z"),
+		Version:    1607013727326658202,
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {

--- a/axiom/orgs.go
+++ b/axiom/orgs.go
@@ -153,10 +153,10 @@ type Organization struct {
 	PrimaryEmail string `json:"primaryEmail"`
 	// License of the deployment or organization.
 	License License `json:"license"`
-	// Created is the time the Organization was created.
-	Created time.Time `json:"metaCreated"`
-	// Modified is the time the Organization was modified.
-	Modified time.Time `json:"metaModified"`
+	// CreatedAt is the time the Organization was created.
+	CreatedAt time.Time `json:"metaCreated"`
+	// ModifiedAt is the time the Organization was last modified.
+	ModifiedAt time.Time `json:"metaModified"`
 	// Version of the organization.
 	Version string `json:"metaVersion"`
 }

--- a/axiom/orgs_test.go
+++ b/axiom/orgs_test.go
@@ -50,9 +50,9 @@ func TestOrganizationsService_List(t *testing.T) {
 				},
 				Error: "",
 			},
-			Created:  mustTimeParse(t, time.RFC3339, "1970-01-01T00:00:00Z"),
-			Modified: mustTimeParse(t, time.RFC3339, "2021-03-11T13:27:28.501218883Z"),
-			Version:  "1615469248501218883",
+			CreatedAt:  mustTimeParse(t, time.RFC3339, "1970-01-01T00:00:00Z"),
+			ModifiedAt: mustTimeParse(t, time.RFC3339, "2021-03-11T13:27:28.501218883Z"),
+			Version:    "1615469248501218883",
 		},
 	}
 
@@ -151,9 +151,9 @@ func TestOrganizationsService_Get(t *testing.T) {
 			},
 			Error: "",
 		},
-		Created:  mustTimeParse(t, time.RFC3339, "1970-01-01T00:00:00Z"),
-		Modified: mustTimeParse(t, time.RFC3339, "2021-03-11T13:27:28.501218883Z"),
-		Version:  "1615469248501218883",
+		CreatedAt:  mustTimeParse(t, time.RFC3339, "1970-01-01T00:00:00Z"),
+		ModifiedAt: mustTimeParse(t, time.RFC3339, "2021-03-11T13:27:28.501218883Z"),
+		Version:    "1615469248501218883",
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {
@@ -310,9 +310,9 @@ func TestOrganizationsService_Update(t *testing.T) {
 			},
 			Error: "",
 		},
-		Created:  mustTimeParse(t, time.RFC3339, "1970-01-01T00:00:00Z"),
-		Modified: mustTimeParse(t, time.RFC3339, "2021-03-11T13:27:28.501218883Z"),
-		Version:  "1615469248501218883",
+		CreatedAt:  mustTimeParse(t, time.RFC3339, "1970-01-01T00:00:00Z"),
+		ModifiedAt: mustTimeParse(t, time.RFC3339, "2021-03-11T13:27:28.501218883Z"),
+		Version:    "1615469248501218883",
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {

--- a/axiom/starred.go
+++ b/axiom/starred.go
@@ -88,8 +88,8 @@ type StarredQuery struct {
 	Query query.Query `json:"query"`
 	// Metadata associated with the query.
 	Metadata map[string]string `json:"metadata"`
-	// Created is the time the starred query was created at.
-	Created time.Time `json:"created"`
+	// CreatedAt is the time the starred query was created.
+	CreatedAt time.Time `json:"created"`
 }
 
 // StarredQueriesListOptions specifies the parameters for the List method of the

--- a/axiom/starred_test.go
+++ b/axiom/starred_test.go
@@ -37,7 +37,7 @@ func TestStarredQueriesService_List(t *testing.T) {
 			Metadata: map[string]string{
 				"quickRange": "30m",
 			},
-			Created: mustTimeParse(t, time.RFC3339Nano, "2020-11-24T16:53:38.267775284Z"),
+			CreatedAt: mustTimeParse(t, time.RFC3339Nano, "2020-11-24T16:53:38.267775284Z"),
 		},
 	}
 
@@ -115,7 +115,7 @@ func TestStarredQueriesService_Get(t *testing.T) {
 		Metadata: map[string]string{
 			"quickRange": "30m",
 		},
-		Created: mustTimeParse(t, time.RFC3339Nano, "2020-11-24T16:53:38.267775284Z"),
+		CreatedAt: mustTimeParse(t, time.RFC3339Nano, "2020-11-24T16:53:38.267775284Z"),
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {
@@ -170,7 +170,7 @@ func TestStarredQueriesService_Create(t *testing.T) {
 		Metadata: map[string]string{
 			"quickRange": "7d",
 		},
-		Created: mustTimeParse(t, time.RFC3339Nano, "2020-11-25T17:34:07.659355723Z"),
+		CreatedAt: mustTimeParse(t, time.RFC3339Nano, "2020-11-25T17:34:07.659355723Z"),
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {
@@ -232,7 +232,7 @@ func TestStarredQueriesService_Update(t *testing.T) {
 		Metadata: map[string]string{
 			"quickRange": "7d",
 		},
-		Created: mustTimeParse(t, time.RFC3339Nano, "2020-11-25T17:34:07.659355723Z"),
+		CreatedAt: mustTimeParse(t, time.RFC3339Nano, "2020-11-25T17:34:07.659355723Z"),
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {

--- a/axiom/vfields.go
+++ b/axiom/vfields.go
@@ -11,12 +11,10 @@ type VirtualField struct {
 	ID string `json:"id"`
 	// Dataset the virtual field belongs to.
 	Dataset string `json:"dataset"`
-	// Name is the display name of the virtual field.
+	// Name the virtual field is referenced by.
 	Name string `json:"name"`
 	// Description of the virtual field.
 	Description string `json:"description"`
-	// Alias the virtual field is referenced by.
-	Alias string `json:"alias"`
 	// Expression that evaluates the virtual fields value.
 	Expression string `json:"expression"`
 }

--- a/axiom/vfields_integration_test.go
+++ b/axiom/vfields_integration_test.go
@@ -42,7 +42,7 @@ func (s *VirtualFieldsTestSuite) SetupSuite() {
 		Dataset:     dataset.ID,
 		Name:        "status_failed",
 		Description: "Failed Requests",
-		Expression:  "response >= 400",
+		Expression:  "response > 399",
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(s.virtualField)
@@ -67,9 +67,9 @@ func (s *VirtualFieldsTestSuite) Test() {
 	// Let's update the virtual field.
 	virtualField, err := s.client.VirtualFields.Update(s.suiteCtx, s.virtualField.ID, axiom.VirtualField{
 		Dataset:     s.datasetID,
-		Name:        "status_failed",
-		Description: "Failed Requests",
-		Expression:  "response > 399",
+		Name:        "status_bad",
+		Description: "Bad Requests",
+		Expression:  "response == 400",
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(virtualField)

--- a/axiom/vfields_integration_test.go
+++ b/axiom/vfields_integration_test.go
@@ -40,9 +40,8 @@ func (s *VirtualFieldsTestSuite) SetupSuite() {
 
 	s.virtualField, err = s.client.VirtualFields.Create(s.suiteCtx, axiom.VirtualField{
 		Dataset:     dataset.ID,
-		Name:        "Failed Requests",
-		Description: "Statuses >= 400",
-		Alias:       "status_failed",
+		Name:        "status_failed",
+		Description: "Failed Requests",
 		Expression:  "response >= 400",
 	})
 	s.Require().NoError(err)
@@ -68,9 +67,8 @@ func (s *VirtualFieldsTestSuite) Test() {
 	// Let's update the virtual field.
 	virtualField, err := s.client.VirtualFields.Update(s.suiteCtx, s.virtualField.ID, axiom.VirtualField{
 		Dataset:     s.datasetID,
-		Name:        "Failed Requests",
-		Description: "Statuses > 399",
-		Alias:       "status_failed",
+		Name:        "status_failed",
+		Description: "Failed Requests",
 		Expression:  "response > 399",
 	})
 	s.Require().NoError(err)

--- a/axiom/vfields_test.go
+++ b/axiom/vfields_test.go
@@ -13,11 +13,11 @@ import (
 func TestVirtualFieldsService_List(t *testing.T) {
 	exp := []*VirtualField{
 		{
-			ID:          "PiGheBIFBc4Khn4dBZ",
+			ID:          "test.status_success",
 			Dataset:     "test",
 			Name:        "status_success",
 			Description: "Successful Requests",
-			Expression:  "response <= 200 && response < 400",
+			Expression:  "response < 400",
 		},
 	}
 
@@ -31,10 +31,10 @@ func TestVirtualFieldsService_List(t *testing.T) {
 		_, err := fmt.Fprint(w, `[
 			{
 				"dataset": "test",
-				"name": "status_success",
 				"description": "Successful Requests",
-				"expression": "response <= 200 && response < 400",
-				"id": "PiGheBIFBc4Khn4dBZ"
+				"name": "status_success",
+				"expression": "response < 400",
+				"id": "test.status_success"
 			}
 		]`)
 		assert.NoError(t, err)
@@ -57,11 +57,11 @@ func TestVirtualFieldsService_List(t *testing.T) {
 
 func TestVirtualFieldsService_Get(t *testing.T) {
 	exp := &VirtualField{
-		ID:          "PiGheBIFBc4Khn4dBZ",
+		ID:          "test.status_success",
 		Dataset:     "test",
 		Name:        "status_success",
 		Description: "Successful Requests",
-		Expression:  "response <= 200 && response < 400",
+		Expression:  "response < 400",
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {
@@ -69,18 +69,18 @@ func TestVirtualFieldsService_Get(t *testing.T) {
 
 		_, err := fmt.Fprint(w, `{
 			"dataset": "test",
-			"name": "status_success",
 			"description": "Successful Requests",
-			"expression": "response <= 200 && response < 400",
-			"id": "PiGheBIFBc4Khn4dBZ"
+			"name": "status_success",
+			"expression": "response < 400",
+			"id": "test.status_success"
 		}`)
 		assert.NoError(t, err)
 	}
 
-	client, teardown := setup(t, "/api/v1/vfields/PiGheBIFBc4Khn4dBZ", hf)
+	client, teardown := setup(t, "/api/v1/vfields/test.status_success", hf)
 	defer teardown()
 
-	res, err := client.VirtualFields.Get(context.Background(), "PiGheBIFBc4Khn4dBZ")
+	res, err := client.VirtualFields.Get(context.Background(), "test.status_success")
 	require.NoError(t, err)
 
 	assert.Equal(t, exp, res)
@@ -88,11 +88,11 @@ func TestVirtualFieldsService_Get(t *testing.T) {
 
 func TestVirtualFieldsService_Create(t *testing.T) {
 	exp := &VirtualField{
-		ID:          "FmgciXxL3njoNgzWVR",
+		ID:          "status_failed",
 		Dataset:     "test",
 		Name:        "status_failed",
 		Description: "Failed Requests",
-		Expression:  "response >= 400",
+		Expression:  "response > 399",
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {
@@ -101,10 +101,10 @@ func TestVirtualFieldsService_Create(t *testing.T) {
 
 		_, err := fmt.Fprint(w, `{
 			"dataset": "test",
-			"name": "status_failed",
 			"description": "Failed Requests",
-			"expression": "response >= 400",
-			"id": "FmgciXxL3njoNgzWVR"
+			"name": "status_failed",
+			"expression": "response > 399",
+			"id": "status_failed"
 		}`)
 		assert.NoError(t, err)
 	}
@@ -116,7 +116,7 @@ func TestVirtualFieldsService_Create(t *testing.T) {
 		Dataset:     "test",
 		Name:        "status_failed",
 		Description: "Failed Requests",
-		Expression:  "response >= 400",
+		Expression:  "response > 399",
 	})
 	require.NoError(t, err)
 
@@ -125,7 +125,7 @@ func TestVirtualFieldsService_Create(t *testing.T) {
 
 func TestVirtualFieldsService_Update(t *testing.T) {
 	exp := &VirtualField{
-		ID:          "FmgciXxL3njoNgzWVR",
+		ID:          "status_failed",
 		Dataset:     "test",
 		Name:        "status_failed",
 		Description: "Failed Requests",
@@ -138,18 +138,18 @@ func TestVirtualFieldsService_Update(t *testing.T) {
 
 		_, err := fmt.Fprint(w, `{
 			"dataset": "test",
-			"name": "status_failed",
 			"description": "Failed Requests",
+			"name": "status_failed",
 			"expression": "response > 399",
-			"id": "FmgciXxL3njoNgzWVR"
+			"id": "status_failed"
 		}`)
 		assert.NoError(t, err)
 	}
 
-	client, teardown := setup(t, "/api/v1/vfields/FmgciXxL3njoNgzWVR", hf)
+	client, teardown := setup(t, "/api/v1/vfields/status_failed", hf)
 	defer teardown()
 
-	res, err := client.VirtualFields.Update(context.Background(), "FmgciXxL3njoNgzWVR", VirtualField{
+	res, err := client.VirtualFields.Update(context.Background(), "status_failed", VirtualField{
 		Dataset:     "test",
 		Name:        "status_failed",
 		Description: "Failed Requests",
@@ -167,9 +167,9 @@ func TestVirtualFieldsService_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}
 
-	client, teardown := setup(t, "/api/v1/vfields/FmgciXxL3njoNgzWVR", hf)
+	client, teardown := setup(t, "/api/v1/vfields/status_failed", hf)
 	defer teardown()
 
-	err := client.VirtualFields.Delete(context.Background(), "FmgciXxL3njoNgzWVR")
+	err := client.VirtualFields.Delete(context.Background(), "status_failed")
 	require.NoError(t, err)
 }

--- a/axiom/vfields_test.go
+++ b/axiom/vfields_test.go
@@ -15,9 +15,8 @@ func TestVirtualFieldsService_List(t *testing.T) {
 		{
 			ID:          "PiGheBIFBc4Khn4dBZ",
 			Dataset:     "test",
-			Name:        "Successful Requests",
-			Description: "Statuses <= x < 400",
-			Alias:       "status_success",
+			Name:        "status_success",
+			Description: "Successful Requests",
 			Expression:  "response <= 200 && response < 400",
 		},
 	}
@@ -32,9 +31,8 @@ func TestVirtualFieldsService_List(t *testing.T) {
 		_, err := fmt.Fprint(w, `[
 			{
 				"dataset": "test",
-				"name": "Successful Requests",
-				"description": "Statuses <= x < 400",
-				"alias": "status_success",
+				"name": "status_success",
+				"description": "Successful Requests",
 				"expression": "response <= 200 && response < 400",
 				"id": "PiGheBIFBc4Khn4dBZ"
 			}
@@ -61,9 +59,8 @@ func TestVirtualFieldsService_Get(t *testing.T) {
 	exp := &VirtualField{
 		ID:          "PiGheBIFBc4Khn4dBZ",
 		Dataset:     "test",
-		Name:        "Successful Requests",
-		Description: "Statuses <= x < 400",
-		Alias:       "status_success",
+		Name:        "status_success",
+		Description: "Successful Requests",
 		Expression:  "response <= 200 && response < 400",
 	}
 
@@ -72,9 +69,8 @@ func TestVirtualFieldsService_Get(t *testing.T) {
 
 		_, err := fmt.Fprint(w, `{
 			"dataset": "test",
-			"name": "Successful Requests",
-			"description": "Statuses <= x < 400",
-			"alias": "status_success",
+			"name": "status_success",
+			"description": "Successful Requests",
 			"expression": "response <= 200 && response < 400",
 			"id": "PiGheBIFBc4Khn4dBZ"
 		}`)
@@ -94,9 +90,8 @@ func TestVirtualFieldsService_Create(t *testing.T) {
 	exp := &VirtualField{
 		ID:          "FmgciXxL3njoNgzWVR",
 		Dataset:     "test",
-		Name:        "Failed Requests",
-		Description: "Statuses >= 400",
-		Alias:       "status_failed",
+		Name:        "status_failed",
+		Description: "Failed Requests",
 		Expression:  "response >= 400",
 	}
 
@@ -106,9 +101,8 @@ func TestVirtualFieldsService_Create(t *testing.T) {
 
 		_, err := fmt.Fprint(w, `{
 			"dataset": "test",
-			"name": "Failed Requests",
-			"description": "Statuses >= 400",
-			"alias": "status_failed",
+			"name": "status_failed",
+			"description": "Failed Requests",
 			"expression": "response >= 400",
 			"id": "FmgciXxL3njoNgzWVR"
 		}`)
@@ -120,9 +114,8 @@ func TestVirtualFieldsService_Create(t *testing.T) {
 
 	res, err := client.VirtualFields.Create(context.Background(), VirtualField{
 		Dataset:     "test",
-		Name:        "Failed Requests",
-		Description: "Statuses >= 400",
-		Alias:       "status_failed",
+		Name:        "status_failed",
+		Description: "Failed Requests",
 		Expression:  "response >= 400",
 	})
 	require.NoError(t, err)
@@ -134,9 +127,8 @@ func TestVirtualFieldsService_Update(t *testing.T) {
 	exp := &VirtualField{
 		ID:          "FmgciXxL3njoNgzWVR",
 		Dataset:     "test",
-		Name:        "Failed Requests",
-		Description: "Statuses > 399",
-		Alias:       "status_failed",
+		Name:        "status_failed",
+		Description: "Failed Requests",
 		Expression:  "response > 399",
 	}
 
@@ -146,9 +138,8 @@ func TestVirtualFieldsService_Update(t *testing.T) {
 
 		_, err := fmt.Fprint(w, `{
 			"dataset": "test",
-			"name": "Failed Requests",
-			"description": "Statuses > 399",
-			"alias": "status_failed",
+			"name": "status_failed",
+			"description": "Failed Requests",
 			"expression": "response > 399",
 			"id": "FmgciXxL3njoNgzWVR"
 		}`)
@@ -160,9 +151,8 @@ func TestVirtualFieldsService_Update(t *testing.T) {
 
 	res, err := client.VirtualFields.Update(context.Background(), "FmgciXxL3njoNgzWVR", VirtualField{
 		Dataset:     "test",
-		Name:        "Failed Requests",
-		Description: "Statuses > 399",
-		Alias:       "status_failed",
+		Name:        "status_failed",
+		Description: "Failed Requests",
 		Expression:  "response > 399",
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
This change is going to be part of the Axiom API 1.10 release.

Will tag v0.4.0 upon AxiomDB release.