### PR TITLE
Add IncludeCursor field to query request

### DIFF
--- a/axiom/monitors_test.go
+++ b/axiom/monitors_test.go
@@ -304,6 +304,7 @@ func TestMonitor_MarshalJSON(t *testing.T) {
 			},
 			"groupBy": null,
 			"order": null,
+			"includeCursor": false,
 			"limit": 0,
 			"virtualFields": null,
 			"project": null,

--- a/axiom/query/query.go
+++ b/axiom/query/query.go
@@ -36,6 +36,9 @@ type Query struct {
 	// Cursor is the query cursor. It should be set to the Cursor returned with
 	// a previous query result if it was partial.
 	Cursor string `json:"cursor"`
+	// IncludeCursor will return the Cursor as part of the query result, if set
+	// to true.
+	IncludeCursor bool `json:"includeCursor"`
 	// ContinuationToken is used to get more results of a previous query. It is
 	// not valid for starred queries or otherwise stored queries.
 	ContinuationToken string `json:"continuationToken"`


### PR DESCRIPTION
This change was part of the Axiom API 1.9 release.

Will tag v0.2.0 release soon after merge.