### PR TITLE
Replace all ioutil.ReadAll calls with io.ReadAll

### DIFF
--- a/adapters/apex/apex_test.go
+++ b/adapters/apex/apex_test.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -31,7 +31,7 @@ func TestHook(t *testing.T) {
 		gzr, err := gzip.NewReader(r.Body)
 		require.NoError(t, err)
 
-		b, err := ioutil.ReadAll(gzr)
+		b, err := io.ReadAll(gzr)
 		assert.NoError(t, err)
 
 		JSONEq(t, exp, string(b), []string{axiom.TimestampField})

--- a/adapters/logrus/logrus_test.go
+++ b/adapters/logrus/logrus_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -30,7 +31,7 @@ func TestHook(t *testing.T) {
 		gzr, err := gzip.NewReader(r.Body)
 		require.NoError(t, err)
 
-		b, err := ioutil.ReadAll(gzr)
+		b, err := io.ReadAll(gzr)
 		assert.NoError(t, err)
 
 		assert.JSONEq(t, exp, string(b))

--- a/adapters/zap/zap_test.go
+++ b/adapters/zap/zap_test.go
@@ -3,7 +3,7 @@ package zap_test
 import (
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -28,7 +28,7 @@ func TestCore(t *testing.T) {
 		gzr, err := gzip.NewReader(r.Body)
 		require.NoError(t, err)
 
-		b, err := ioutil.ReadAll(gzr)
+		b, err := io.ReadAll(gzr)
 		assert.NoError(t, err)
 
 		assert.JSONEq(t, exp, string(b))

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -768,7 +767,7 @@ func TestGZIPStreamer(t *testing.T) {
 		require.NoError(t, closeErr)
 	}()
 
-	act, err := ioutil.ReadAll(gzr)
+	act, err := io.ReadAll(gzr)
 	require.NoError(t, err)
 
 	assert.Equal(t, exp, string(act))


### PR DESCRIPTION
As of Go 1.16, `ioutil.ReadAll` just calls `io.ReadAll`.