### PR TITLE
Improved testing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,18 +5,20 @@ on:
     branches:
       - main
 
-env:
-  GOVERSION: "1.16"
-
 jobs:
   gen-diff:
     name: Codegen diff
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.16
+          - 1.17
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ env.GOVERSION }}
+          go-version: ${{ matrix.go }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -31,22 +33,38 @@ jobs:
     name: Lint
     needs: gen-diff
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.16
+          - 1.17
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ env.GOVERSION }}
+          go-version: ${{ matrix.go }}
       - uses: golangci/golangci-lint-action@v2
+        with:
+          skip-go-installation: true
 
   test:
     name: Test
     needs: lint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.16
+          - 1.17
+        include:
+          - go: 1.17
+            update-coverage: true
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ env.GOVERSION }}
+          go-version: ${{ matrix.go }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -62,7 +80,10 @@ jobs:
         env:
           AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
           AXIOM_URL: ${{ secrets.TESTING_AZURE_1_STAGING_DEPLOYMENT_URL }}
+          AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ matrix.go }}
         run: make test-integration
-      - uses: codecov/codecov-action@v1
+      - name: Update Coverage
+        if: ${{ matrix.update-coverage }}
+        uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,18 +5,20 @@ on:
     branches:
       - main
 
-env:
-  GOVERSION: "1.16"
-
 jobs:
   gen-diff:
     name: Codegen diff
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.16
+          - 1.17
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ env.GOVERSION }}
+          go-version: ${{ matrix.go }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -31,22 +33,38 @@ jobs:
     name: Lint
     needs: gen-diff
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.16
+          - 1.17
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ env.GOVERSION }}
+          go-version: ${{ matrix.go }}
       - uses: golangci/golangci-lint-action@v2
+        with:
+          skip-go-installation: true
 
   test:
     name: Test
     needs: lint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.16
+          - 1.17
+        include:
+          - go: 1.17
+            update-coverage: true
+            update-goreportcard: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ env.GOVERSION }}
+          go-version: ${{ matrix.go }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -57,8 +75,13 @@ jobs:
       - env:
           AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
           AXIOM_URL: ${{ secrets.TESTING_AZURE_1_STAGING_DEPLOYMENT_URL }}
+          AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ matrix.go }}
         run: make test-integration
-      - uses: codecov/codecov-action@v1
+      - name: Update Coverage
+        if: ${{ matrix.update-coverage }}
+        uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
-      - uses: creekorful/goreportcard-action@v1.0
+      - name: Update Go Report Card
+        if: ${{ matrix.update-goreportcard }}
+        uses: creekorful/goreportcard-action@v1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@ name: Release
 on:
   push:
     tags:
-      - "*"
+      - "v*"
 
 env:
-  GOVERSION: "1.16"
+  GOVERSION: "1.17"
 
 jobs:
   release:
@@ -30,4 +30,4 @@ jobs:
         with:
           args: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/server-regression.yml
+++ b/.github/workflows/server-regression.yml
@@ -1,11 +1,11 @@
-name: Server regression
+name: Server Regression
 
 on:
   schedule:
-    - cron: "0 12 * * *"
+    - cron: "0 0 * * *"
 
 env:
-  GOVERSION: "1.16"
+  GOVERSION: "1.17"
 
 jobs:
   test:
@@ -26,4 +26,5 @@ jobs:
       - env:
           AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
           AXIOM_URL: ${{ secrets.TESTING_AZURE_1_STAGING_DEPLOYMENT_URL }}
+          AXIOM_DATASET_SUFFIX: ${{ github.run_id }}
         run: make test-integration

--- a/README.md
+++ b/README.md
@@ -24,22 +24,22 @@
 Axiom Go is a Go client library for accessing the [Axiom](https://www.axiom.co/)
 API.
 
-Currently, **Axiom Go requires Go 1.12 or greater**.
+Currently, **Axiom Go requires Go 1.16 or greater**.
 
 ## Installation
 
 ### Install using `go get`
 
 ```shell
- go get github.com/axiomhq/axiom-go/axiom
+go get github.com/axiomhq/axiom-go/axiom
 ```
 
 ### Install from source
 
 ```shell
- git clone https://github.com/axiomhq/axiom-go.git
- cd axiom-go
- make # Run code generators, linters, sanitizers and test suits
+git clone https://github.com/axiomhq/axiom-go.git
+cd axiom-go
+make # Run code generators, linters, sanitizers and test suits
 ```
 
 ## Authentication

--- a/axiom/client_integration_test.go
+++ b/axiom/client_integration_test.go
@@ -5,7 +5,6 @@ package axiom_test
 import (
 	"context"
 	"flag"
-	"math/rand"
 	"os"
 	"time"
 
@@ -18,16 +17,16 @@ var (
 	accessToken    string
 	orgID          string
 	deploymentURL  string
+	datasetSuffix  string
 	historyQueryID string
 	strictDecoding = true
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
-
 	flag.StringVar(&accessToken, "access-token", os.Getenv("AXIOM_TOKEN"), "Personal Access Token of the test user")
 	flag.StringVar(&orgID, "org-id", os.Getenv("AXIOM_ORG_ID"), "Organization ID of the organization the test user belongs to")
 	flag.StringVar(&deploymentURL, "deployment-url", os.Getenv("AXIOM_URL"), "URL of the deployment to test against")
+	flag.StringVar(&datasetSuffix, "dataset-suffix", os.Getenv("AXIOM_DATASET_SUFFIX"), "Dataset suffix to append to test datasets")
 	flag.StringVar(&historyQueryID, "history-query-id", os.Getenv("AXIOM_HISTORY_QUERY_ID"), "ID of the query to get from history")
 	flag.BoolVar(&strictDecoding, "strict-decoding", os.Getenv("AXIOM_STRICT_DECODING") == "", "Disable strict JSON response decoding by setting -strict-decoding=false")
 }
@@ -111,14 +110,4 @@ func newClient(orgID, deploymentURL, accessToken string) (*axiom.Client, error) 
 	}
 
 	return client, err
-}
-
-var runePool = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-
-func randString() string {
-	b := make([]rune, 12)
-	for i := range b {
-		b[i] = runePool[rand.Intn(len(runePool))] //nolint:gosec // We don't need secure randomness for tests :)
-	}
-	return string(b)
 }

--- a/axiom/datasets_integration_test.go
+++ b/axiom/datasets_integration_test.go
@@ -79,7 +79,7 @@ func (s *DatasetsTestSuite) SetupSuite() {
 
 	var err error
 	s.dataset, err = s.client.Datasets.Create(s.suiteCtx, axiom.DatasetCreateRequest{
-		Name:        "test-axiom-go-dataset-" + randString(),
+		Name:        "test-axiom-go-datasets-" + datasetSuffix,
 		Description: "This is a test dataset for datasets integration tests.",
 	})
 	s.Require().NoError(err)
@@ -191,8 +191,8 @@ func (s *DatasetsTestSuite) Test() {
 	s.Require().NoError(err)
 	s.Require().NotNil(trimResult)
 
-	// HINT(lukasmalkmus): There are no blocks to trim, yet.
-	// s.EqualValues(1, trimResult.BlocksDeleted)
+	// HINT(lukasmalkmus): There are no blocks to trim in this test.
+	s.EqualValues(0, trimResult.BlocksDeleted)
 }
 
 func (s *DatasetsTestSuite) TestHistory() {

--- a/axiom/monitors_integration_test.go
+++ b/axiom/monitors_integration_test.go
@@ -31,7 +31,7 @@ func (s *MonitorsTestSuite) SetupSuite() {
 	s.IntegrationTestSuite.SetupSuite()
 
 	dataset, err := s.client.Datasets.Create(s.suiteCtx, axiom.DatasetCreateRequest{
-		Name:        "test-axiom-go-monitors-" + randString(),
+		Name:        "test-axiom-go-monitors-" + datasetSuffix,
 		Description: "This is a test dataset for monitors integration tests.",
 	})
 	s.Require().NoError(err)

--- a/axiom/starred_integration_test.go
+++ b/axiom/starred_integration_test.go
@@ -30,7 +30,7 @@ func (s *StarredQueriesTestSuite) SetupSuite() {
 	s.IntegrationTestSuite.SetupSuite()
 
 	dataset, err := s.client.Datasets.Create(s.suiteCtx, axiom.DatasetCreateRequest{
-		Name:        "test-axiom-go-starred-queries-" + randString(),
+		Name:        "test-axiom-go-starred-queries-" + datasetSuffix,
 		Description: "This is a test dataset for starred queries integration tests.",
 	})
 	s.Require().NoError(err)
@@ -65,7 +65,6 @@ func (s *StarredQueriesTestSuite) TearDownSuite() {
 func (s *StarredQueriesTestSuite) Test() {
 	// Let's update the starredQuery.
 	starredQuery, err := s.client.StarredQueries.Update(s.suiteCtx, s.starredQuery.ID, axiom.StarredQuery{
-		Kind:    axiom.Analytics,
 		Dataset: s.datasetID,
 		Name:    "Updated Test Query",
 	})
@@ -80,8 +79,7 @@ func (s *StarredQueriesTestSuite) Test() {
 	s.Require().NoError(err)
 	s.Require().NotNil(starredQuery)
 
-	// TODO(lukasmalkmus): This needs a server-side fix.
-	// s.Equal(s.starredQuery, starredQuery)
+	s.Equal(s.starredQuery, starredQuery)
 
 	// List all starred queries and make sure the created starred query is part
 	// of that list.

--- a/axiom/users_integration_test.go
+++ b/axiom/users_integration_test.go
@@ -53,7 +53,7 @@ func (s *UsersTestSuite) TearDownSuite() {
 
 func (s *UsersTestSuite) Test() {
 	// Let's update the user.
-	// TODO(lukasmalkmus): Cannot update other users at this point. So we just
+	// HINT(lukasmalkmus): Cannot update other users at this point. So we just
 	// update the test suites user (ourselves) with the same data to make sure
 	// the method call passes.
 	user, err := s.client.Users.Update(s.suiteCtx, s.testUser.ID, axiom.UserUpdateRequest{

--- a/axiom/vfields_integration_test.go
+++ b/axiom/vfields_integration_test.go
@@ -30,7 +30,7 @@ func (s *VirtualFieldsTestSuite) SetupSuite() {
 	s.IntegrationTestSuite.SetupSuite()
 
 	dataset, err := s.client.Datasets.Create(s.suiteCtx, axiom.DatasetCreateRequest{
-		Name:        "test-axiom-go-virtual-fields-" + randString(),
+		Name:        "test-axiom-go-virtual-fields-" + datasetSuffix,
 		Description: "This is a test dataset for virtual fields integration tests.",
 	})
 	s.Require().NoError(err)


### PR DESCRIPTION
* Support the latest two Go releases and properly test against them
* Only update coverage and and code quality report from tests that ran the latest Go release
* Introduce `AXIOM_DATASET_PREFIX` as in `axiom-node` to uniquely identify a test dataset if it should be left over
* Skip Go installation for the `lint` action
* Use `github.token` instead of `secrets.GITHUB_TOKEN`. The reason for this is that to unexperienced users it looks like `GITHUB_TOKEN` is configured as a repository secret like all the other secretes for the `secrets.*` key. This makes it a bit more implicit, where the token comes from.
* Run regression test at night
* Some README fixes