### PR TITLE
Improved Client and Adapter creation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Test (Integration)
         if: github.event.pull_request.head.repo.full_name == github.repository
         env:
-          AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
           AXIOM_URL: ${{ secrets.TESTING_AZURE_1_STAGING_DEPLOYMENT_URL }}
+          AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
           AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ matrix.go }}
         run: make test-integration
       - name: Update Coverage

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -73,8 +73,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
       - env:
-          AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
           AXIOM_URL: ${{ secrets.TESTING_AZURE_1_STAGING_DEPLOYMENT_URL }}
+          AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
           AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ matrix.go }}
         run: make test-integration
       - name: Update Coverage

--- a/.github/workflows/server_regression.yml
+++ b/.github/workflows/server_regression.yml
@@ -25,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
       - env:
-          AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
           AXIOM_URL: ${{ secrets.TESTING_AZURE_1_STAGING_DEPLOYMENT_URL }}
+          AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
           AXIOM_DATASET_SUFFIX: ${{ github.run_id }}
         run: make test-integration

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -30,8 +30,8 @@ jobs:
               echo '[{"foo":"bar"}]' >> logs.json
       max-parallel: 1
     env:
-      AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
       AXIOM_URL: ${{ secrets.TESTING_AZURE_1_STAGING_DEPLOYMENT_URL }}
+      AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
       AXIOM_DATASET: test-axiom-go-examples-${{ github.run_id }}-${{ matrix.example }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -47,7 +47,7 @@ jobs:
           restore-keys: ${{ runner.os }}-go-
       - name: Setup
         run: |
-          go get -u github.com/axiomhq/cli/cmd/axiom
+          go install github.com/axiomhq/cli/cmd/axiom@latest
           axiom dataset create -n=$AXIOM_DATASET -d="Axiom Go examples test"
       - name: Example Setup
         if: matrix.setup

--- a/README.md
+++ b/README.md
@@ -57,10 +57,8 @@ for.
 ## Usage
 
 ```go
-var (
-	deploymentURL = os.Getenv("AXIOM_URL")
-	accessToken   = os.Getenv("AXIOM_TOKEN")
-)
+// Export `AXIOM_TOKEN` and `AXIOM_ORG_ID` for Axiom Cloud
+// Export `AXIOM_URL` and `AXIOM_TOKEN` for Axiom Selfhost
 
 // 1. Open the file to ingest.
 f, err := os.Open("logs.json")
@@ -76,7 +74,7 @@ if err != nil {
 }
 
 // 3. Initialize the Axiom API client.
-client, err := axiom.NewClient(deploymentURL, accessToken)
+client, err := axiom.NewClient()
 if err != nil {
 	log.Fatal(err)
 }

--- a/axiom/client_integration_test.go
+++ b/axiom/client_integration_test.go
@@ -86,30 +86,16 @@ func (s *IntegrationTestSuite) TearDownTest() {
 }
 
 func (s *IntegrationTestSuite) newClient() {
-	var err error
-	s.client, err = newClient(orgID, deploymentURL, accessToken)
-
+	var (
+		userAgent = "axiom-go-integration-test/" + datasetSuffix
+		err       error
+	)
+	s.client, err = axiom.NewClient(
+		axiom.SetURL(deploymentURL),
+		axiom.SetAccessToken(accessToken),
+		axiom.SetOrgID(orgID),
+		axiom.SetUserAgent(userAgent),
+	)
 	s.Require().NoError(err)
 	s.Require().NotNil(s.client)
-}
-
-func newClient(orgID, deploymentURL, accessToken string) (*axiom.Client, error) {
-	options := []axiom.Option{
-		axiom.SetUserAgent("axiom-go-integration-test"),
-	}
-
-	var (
-		client *axiom.Client
-		err    error
-	)
-	if orgID != "" {
-		if deploymentURL != "" {
-			options = append(options, axiom.SetBaseURL(deploymentURL))
-		}
-		client, err = axiom.NewCloudClient(orgID, accessToken, options...)
-	} else {
-		client, err = axiom.NewClient(deploymentURL, accessToken, options...)
-	}
-
-	return client, err
 }

--- a/axiom/doc.go
+++ b/axiom/doc.go
@@ -6,21 +6,18 @@
 //   import "github.com/axiomhq/axiom-go/axiom/query" // When constructing queries
 //
 // Construct a new Axiom client, then use the various services on the client to
-// access different parts of the Axiom API. A valid deployment URL and an access
-// token must be passed. The access token can be a personal one or an ingest
-// token. The ingest token however, will just allow ingestion into the datasets
-// targeted by the ingest token:
+// access different parts of the Axiom API. The package automatically takes its
+// configuration from the environment if not specified otherwise. Refer to
+// `NewClient()` for details. The configuration also differs when connection to
+// Axiom Cloud or Axiom Selfhost. Either way, the access token can be a personal
+// or an ingest token. The ingest token however, will just allow ingestion into
+// the datasets targeted by the ingest token:
 //
-//   client, err := axiom.NewClient("https://my-axiom.example.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
+//   client, err := axiom.NewClient()
 //
 // Get the version of the configured deployment:
 //
 //   version, err := client.Version.Get(ctx)
-//
-// There is an alternate constructor to connect to Axiom Cloud, by providing
-// just the access token and organization identifier:
-//
-//   client, err := axiom.NewCloudClient("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX", "my-org-id")
 //
 // Some API methods have additional parameters that can be passed:
 //

--- a/axiom/example_test.go
+++ b/axiom/example_test.go
@@ -9,7 +9,10 @@ import (
 )
 
 func Example() {
-	client, err := axiom.NewClient("https://my-axiom.example.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
+	// Export `AXIOM_TOKEN` and `AXIOM_ORG_ID` for Axiom Cloud
+	// Export `AXIOM_URL` and `AXIOM_TOKEN` for Axiom Selfhost
+
+	client, err := axiom.NewClient()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/axiom/tokens_integration_test.go
+++ b/axiom/tokens_integration_test.go
@@ -86,13 +86,18 @@ func (s *TokensTestSuite) Update() {
 
 	// Create a separate client that uses the ingest token as authentication
 	// token and test the Validate() method.
-	oldClient := s.client
-	s.client, err = newClient(orgID, deploymentURL, rawToken.Token)
-	s.Require().NoError(err)
-	s.Require().NotNil(s.client)
+	oldClient, oldAccessToken := s.client, accessToken
+	accessToken = rawToken.Token
+	s.newClient()
+	defer func() {
+		s.client, accessToken = oldClient, oldAccessToken
+
+		if strictDecoding {
+			optsErr := s.client.Options(axiom.SetStrictDecoding())
+			s.Require().NoError(optsErr)
+		}
+	}()
 
 	err = s.client.Tokens.Ingest.Validate(s.ctx)
 	s.Require().NoError(err)
-
-	s.client = oldClient
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,30 @@
 # Examples
 
+## Before you start
+
+Axiom Go and the Adapters automatically pick up their configuration from the
+environment, if not otherwise specified. To learn more about cunfiguration,
+check the [Documentation](https://pkg.go.dev/github.com/axiomhq/axiom-go).
+
+To quickstart, export the environment variables below.
+
+### When using Axiom Cloud
+
+* `AXIOM_TOKEN`: **Personal Access** or **Ingest** token. Can be
+  created under `Profile` or `Settings > Ingest Tokens`. For security reasons it
+  is advised to use an Ingest Token with minimal privileges only.
+* `AXIOM_ORG_ID`: Organization identifier of the organization to use on Axiom
+   Cloud.
+* `AXIOM_DATASET`: Dataset to use. Must exist prior to using it.
+
+### When using Axiom Selfhost
+
+* `AXIOM_URL`: URL of the Axiom deployment to use.
+* `AXIOM_TOKEN`: **Personal Access** or **Ingest** token. Can be
+  created under `Profile` or `Settings > Ingest Tokens`. For security reasons it
+  is advised to use an Ingest Token with minimal privileges only.
+* `AXIOM_DATASET`: Dataset to use. Must exist prior to using it.
+
 ## Package usage
 
 * [ingestfile](ingestfile/main.go): How to ingest the contents of a file into

--- a/examples/apex/main.go
+++ b/examples/apex/main.go
@@ -11,14 +11,11 @@ import (
 )
 
 func main() {
-	var (
-		deploymentURL = os.Getenv("AXIOM_URL")
-		accessToken   = os.Getenv("AXIOM_TOKEN")
-		dataset       = os.Getenv("AXIOM_DATASET")
-	)
+	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` and `AXIOM_DATASET` for Axiom Cloud
+	// Export `AXIOM_URL`, `AXIOM_TOKEN` and `AXIOM_DATASET` for Axiom Selfhost
 
 	// 1. Setup the Axiom handler for apex.
-	handler, err := adapter.New(deploymentURL, accessToken, dataset)
+	handler, err := adapter.New()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}

--- a/examples/ingestfile/main.go
+++ b/examples/ingestfile/main.go
@@ -12,10 +12,13 @@ import (
 )
 
 func main() {
-	var (
-		deploymentURL = os.Getenv("AXIOM_URL")
-		accessToken   = os.Getenv("AXIOM_TOKEN")
-	)
+	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` and `AXIOM_DATASET` for Axiom Cloud
+	// Export `AXIOM_URL`, `AXIOM_TOKEN` and `AXIOM_DATASET` for Axiom Selfhost
+
+	dataset := os.Getenv("AXIOM_DATASET")
+	if dataset == "" {
+		log.Fatal("AXIOM_DATASET is required")
+	}
 
 	// 1. Open the file to ingest.
 	f, err := os.Open("logs.json")
@@ -31,7 +34,7 @@ func main() {
 	}
 
 	// 3. Initialize the Axiom API client.
-	client, err := axiom.NewClient(deploymentURL, accessToken)
+	client, err := axiom.NewClient()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -39,7 +42,7 @@ func main() {
 	// 4. Ingest ⚡
 	// Note the JSON content type and GZIP content encoding being set because
 	// the client does not auto sense them.
-	res, err := client.Datasets.Ingest(context.Background(), "test", r, axiom.JSON, axiom.GZIP, axiom.IngestOptions{})
+	res, err := client.Datasets.Ingest(context.Background(), dataset, r, axiom.JSON, axiom.GZIP, axiom.IngestOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/logrus/main.go
+++ b/examples/logrus/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/sirupsen/logrus"
 
@@ -11,14 +10,11 @@ import (
 )
 
 func main() {
-	var (
-		deploymentURL = os.Getenv("AXIOM_URL")
-		accessToken   = os.Getenv("AXIOM_TOKEN")
-		dataset       = os.Getenv("AXIOM_DATASET")
-	)
+	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` and `AXIOM_DATASET` for Axiom Cloud
+	// Export `AXIOM_URL`, `AXIOM_TOKEN` and `AXIOM_DATASET` for Axiom Selfhost
 
 	// 1. Setup the Axiom hook for logrus.
-	hook, err := adapter.New(deploymentURL, accessToken, dataset)
+	hook, err := adapter.New()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/zap/main.go
+++ b/examples/zap/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"go.uber.org/zap"
 
@@ -11,14 +10,11 @@ import (
 )
 
 func main() {
-	var (
-		deploymentURL = os.Getenv("AXIOM_URL")
-		accessToken   = os.Getenv("AXIOM_TOKEN")
-		dataset       = os.Getenv("AXIOM_DATASET")
-	)
+	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` and `AXIOM_DATASET` for Axiom Cloud
+	// Export `AXIOM_URL`, `AXIOM_TOKEN` and `AXIOM_DATASET` for Axiom Selfhost
 
 	// 1. Setup the Axiom core for zap.
-	core, err := adapter.New(deploymentURL, accessToken, dataset)
+	core, err := adapter.New()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -28,7 +24,8 @@ func main() {
 
 	// 3. Have all logs flushed before the application exits.
 	defer func() {
-		// Make sure to handle this error, just in case syncing fails.
+		// Make sure to handle this error in production, just in case syncing
+		// fails.
 		_ = logger.Sync()
 	}()
 


### PR DESCRIPTION
This updates the package to use a single constructor for the `Client` and `adapter/*` types. Configuration is now retrieved from the environment if not specified otherwise. This rougly matches what the AWS SDK does. This reduces a lot of code duplication and confusion we had in place for supporting Axiom Cloud and Selfhost.