### PR TITLE
Improve client options

### DIFF
--- a/axiom/axiom.go
+++ b/axiom/axiom.go
@@ -13,3 +13,16 @@ func IsIngestToken(token string) bool {
 func IsPersonalToken(token string) bool {
 	return strings.HasPrefix(token, "xapt-")
 }
+
+// IsValidToken returns true if the given acces token is a valid Axiom token.
+func IsValidToken(token string) bool {
+	return IsIngestToken(token) || IsPersonalToken(token)
+}
+
+// ValidateEnvironment returns nil if the environment variables, needed to
+// configure a new Client, are present and valid. Otherwise, it returns an
+// appropriate error.
+func ValidateEnvironment() error {
+	var client Client
+	return client.populateClientFromEnvironment()
+}

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -20,6 +20,9 @@ import (
 const CloudURL = "https://cloud.axiom.co"
 
 var (
+	// ErrInvalidToken is returned when the access token is invalid.
+	ErrInvalidToken = errors.New("invalid access token")
+
 	// ErrMissingAccessToken is raised when an access token is not provided. Set
 	// it manually using the SetAccessToken option or export `AXIOM_TOKEN`.
 	ErrMissingAccessToken = errors.New("missing access token")
@@ -92,6 +95,9 @@ type Option func(c *Client) error
 // the `AXIOM_TOKEN` environment variable.
 func SetAccessToken(accessToken string) Option {
 	return func(c *Client) error {
+		if !IsValidToken(accessToken) {
+			return ErrInvalidToken
+		}
 		c.accessToken = accessToken
 		return nil
 	}


### PR DESCRIPTION
This adds two methods:

* `IsTokenValid` makes sure an access token has any valid Axiom prefix
* `ValidateEnvironment` makes sure client creation based on the environment works, without creating one