### PR TITLE
Validate credentials

### DIFF
--- a/axiom/axiom.go
+++ b/axiom/axiom.go
@@ -1,6 +1,9 @@
 package axiom
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
 // IsIngestToken returns true if the given acces token is an ingest token. If
 // false is returned, that does not imply that the token is a personal token.
@@ -20,9 +23,20 @@ func IsValidToken(token string) bool {
 }
 
 // ValidateEnvironment returns nil if the environment variables, needed to
-// configure a new Client, are present and valid. Otherwise, it returns an
-// appropriate error.
+// configure a new Client, are present and syntactically valid. Otherwise, it
+// returns an appropriate error.
 func ValidateEnvironment() error {
 	var client Client
 	return client.populateClientFromEnvironment()
+}
+
+// ValidateCredentials returns nil if the environment variables that configure a
+// Client are valid. Otherwise, it returns an appropriate error. This function
+// establishes a connection to the configured Axiom deployment.
+func ValidateCredentials(ctx context.Context) error {
+	client, err := NewClient()
+	if err != nil {
+		return err
+	}
+	return client.ValidateCredentials(ctx)
 }

--- a/axiom/axiom_integration_test.go
+++ b/axiom/axiom_integration_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+// +build integration
+
+package axiom_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/axiomhq/axiom-go/axiom"
+)
+
+func TestValidateCredentials(t *testing.T) {
+	os.Clearenv()
+
+	os.Setenv("AXIOM_TOKEN", accessToken)
+	os.Setenv("AXIOM_ORG_ID", orgID)
+	os.Setenv("AXIOM_URL", deploymentURL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := axiom.ValidateCredentials(ctx)
+	require.NoError(t, err)
+}

--- a/axiom/client_integration_test.go
+++ b/axiom/client_integration_test.go
@@ -19,7 +19,7 @@ var (
 	orgID          string
 	deploymentURL  string
 	datasetSuffix  string
-	strictDecoding = true
+	strictDecoding bool
 )
 
 func init() {

--- a/axiom/client_integration_test.go
+++ b/axiom/client_integration_test.go
@@ -86,6 +86,11 @@ func (s *IntegrationTestSuite) TearDownTest() {
 	s.cancel()
 }
 
+func (s *IntegrationTestSuite) Test() {
+	err := s.client.ValidateCredentials(s.ctx)
+	s.Require().NoError(err)
+}
+
 func (s *IntegrationTestSuite) newClient() {
 	var (
 		userAgent = "axiom-go-integration-test/" + datasetSuffix

--- a/axiom/client_test.go
+++ b/axiom/client_test.go
@@ -116,9 +116,27 @@ func TestNewClient(t *testing.T) {
 			},
 		},
 		{
+			name: "accessToken and orgID environment enhanced cloudUrl option",
+			environment: map[string]string{
+				"AXIOM_TOKEN":  accessToken,
+				"AXIOM_ORG_ID": orgID,
+			},
+			options: []Option{
+				SetURL(CloudURL + "/"),
+			},
+		},
+		{
 			name: "cloudUrl accessToken and orgID environment no options",
 			environment: map[string]string{
 				"AXIOM_URL":    CloudURL,
+				"AXIOM_TOKEN":  accessToken,
+				"AXIOM_ORG_ID": orgID,
+			},
+		},
+		{
+			name: "enhanced cloudUrl, accessToken and orgID environment no options",
+			environment: map[string]string{
+				"AXIOM_URL":    CloudURL + "/",
 				"AXIOM_TOKEN":  accessToken,
 				"AXIOM_ORG_ID": orgID,
 			},
@@ -143,32 +161,39 @@ func TestNewClient(t *testing.T) {
 			}
 
 			client, err := NewClient(tt.options...)
-
 			if tt.err != nil {
 				assert.EqualError(t, err, tt.err.Error())
 			} else {
-				// Are endpoints/resources present?
-				assert.NotNil(t, client.Dashboards)
-				assert.NotNil(t, client.Datasets)
-				assert.NotNil(t, client.Monitors)
-				assert.NotNil(t, client.Notifiers)
-				assert.NotNil(t, client.Organizations)
-				assert.NotNil(t, client.StarredQueries)
-				assert.NotNil(t, client.Teams)
-				assert.NotNil(t, client.Tokens.Ingest)
-				assert.NotNil(t, client.Tokens.Personal)
-				assert.NotNil(t, client.Users)
-				assert.NotNil(t, client.Version)
-				assert.NotNil(t, client.VirtualFields)
-
-				// Is default configuration present?
 				assert.Equal(t, accessToken, client.accessToken)
-				assert.NotEmpty(t, client.userAgent)
-				assert.False(t, client.strictDecoding)
-				assert.NotNil(t, client.httpClient)
 			}
 		})
 	}
+}
+
+func TestNewClient_Valid(t *testing.T) {
+	client := newClient(t)
+
+	// Are endpoints/resources present?
+	assert.NotNil(t, client.Dashboards)
+	assert.NotNil(t, client.Datasets)
+	assert.NotNil(t, client.Monitors)
+	assert.NotNil(t, client.Notifiers)
+	assert.NotNil(t, client.Organizations)
+	assert.NotNil(t, client.StarredQueries)
+	assert.NotNil(t, client.Teams)
+	assert.NotNil(t, client.Tokens.Ingest)
+	assert.NotNil(t, client.Tokens.Personal)
+	assert.NotNil(t, client.Users)
+	assert.NotNil(t, client.Version)
+	assert.NotNil(t, client.VirtualFields)
+
+	// Is default configuration present?
+	assert.Equal(t, endpoint, client.baseURL.String())
+	assert.Equal(t, accessToken, client.accessToken)
+	assert.Empty(t, client.orgID)
+	assert.NotNil(t, client.httpClient)
+	assert.NotEmpty(t, client.userAgent)
+	assert.False(t, client.strictDecoding)
 }
 
 func TestClient_Options_SetAccessToken(t *testing.T) {

--- a/axiom/client_test.go
+++ b/axiom/client_test.go
@@ -451,10 +451,6 @@ func TestIngestPathRegex(t *testing.T) {
 			match: true,
 		},
 		{
-			input: "/api/v1/datasets/test/ingest?timestamp-field=time",
-			match: true,
-		},
-		{
 			input: "/api/v1/tokens/ingest/validate",
 			match: true,
 		},

--- a/axiom/tokens.go
+++ b/axiom/tokens.go
@@ -108,7 +108,9 @@ func (s *tokensService) Delete(ctx context.Context, id string) error {
 // operations of the Axiom API.
 //
 // Axiom API Reference: /api/v1/tokens/ingest
-type IngestTokensService = tokensService
+type IngestTokensService struct {
+	tokensService
+}
 
 // Validate the token that is used for authentication.
 func (s *IngestTokensService) Validate(ctx context.Context) error {
@@ -119,4 +121,6 @@ func (s *IngestTokensService) Validate(ctx context.Context) error {
 // operations of the Axiom API.
 //
 // Axiom API Reference: /api/v1/tokens/personal
-type PersonalTokensService = tokensService
+type PersonalTokensService struct {
+	tokensService
+}


### PR DESCRIPTION
* New `ValidateCredentials` method to let users validate the client configuration before making calls or knowing any internals of which methods to use for validating different types of tokens
* Improve regex that only matches ingest-token enabled endpoints