### PR TITLE
Fix result aggregation

### DIFF
--- a/axiom/datasets_integration_test.go
+++ b/axiom/datasets_integration_test.go
@@ -215,9 +215,9 @@ func (s *DatasetsTestSuite) Test() {
 		EndTime:   time.Now().UTC(),
 		Aggregations: []query.Aggregation{
 			{
-				Alias: "count",
+				Alias: "event_count",
 				Op:    query.OpCount,
-				// Field: "*",
+				Field: "*",
 			},
 		},
 		GroupBy: []string{"success", "remote_ip"},
@@ -256,7 +256,7 @@ func (s *DatasetsTestSuite) Test() {
 	s.EqualValues(4, complexQueryResult.Status.RowsMatched)
 	if s.Len(complexQueryResult.Buckets.Totals, 2) {
 		agg := complexQueryResult.Buckets.Totals[0].Aggregations[0]
-		s.Equal(query.OpCount, agg.Op)
+		s.EqualValues("event_count", agg.Alias)
 		s.EqualValues(2, agg.Value)
 	}
 

--- a/axiom/query/result.go
+++ b/axiom/query/result.go
@@ -212,8 +212,9 @@ type EntryGroup struct {
 
 // EntryGroupAgg is an aggregation which is part of a group of queried events.
 type EntryGroupAgg struct {
-	// Op is the aggregations operation.
-	Op AggregationOp `json:"op"`
+	// Alias is the aggregations alias. If it wasn't specified at query time, it
+	// is the uppercased string representation of the aggregation operation.
+	Alias string `json:"op"`
 	// Value is the result value of the aggregation.
 	Value interface{} `json:"value"`
 }


### PR DESCRIPTION
Proper datatype and name for a field on the result aggregation.

Closes #71.

Will tag a patch release upon merge.