### PR TITLE
Ignore organization id when using ingest tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ make # Run code generators, linters, sanitizers and test suits
 
 The client is initialized with the url of the deployment and an access token
 when using Axiom Selfhost or an access token and the users organization id when
-using Axiom Cloud.
+using Axiom Cloud. The organization id can be omitted in case an ingest token is
+used.
 
 The access token can be a personal token retrieved from the users profile page
 or an ingest token retrieved from the settings of the Axiom deployment.
@@ -60,8 +61,9 @@ for.
 ## Usage
 
 ```go
-// Export `AXIOM_TOKEN` and `AXIOM_ORG_ID` for Axiom Cloud
-// Export `AXIOM_URL` and `AXIOM_TOKEN` for Axiom Selfhost
+// Export `AXIOM_TOKEN` and `AXIOM_ORG_ID` (when using a personal token) for
+// Axiom Cloud.
+// Export `AXIOM_URL` and `AXIOM_TOKEN` for Axiom Selfhost.
 
 // 1. Open the file to ingest.
 f, err := os.Open("logs.json")

--- a/axiom/axiom_test.go
+++ b/axiom/axiom_test.go
@@ -44,7 +44,7 @@ func TestValidateEnvironment(t *testing.T) {
 	}{
 		{
 			name: "no environment",
-			err:  axiom.ErrMissingOrganizationID,
+			err:  axiom.ErrMissingAccessToken,
 		},
 		{
 			name: "bad environment",

--- a/examples/apex/main.go
+++ b/examples/apex/main.go
@@ -10,7 +10,8 @@ import (
 )
 
 func main() {
-	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` and `AXIOM_DATASET` for Axiom Cloud.
+	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` (when using a personal token) and
+	// `AXIOM_DATASET` for Axiom Cloud.
 	// Export `AXIOM_URL`, `AXIOM_TOKEN` and `AXIOM_DATASET` for Axiom Selfhost.
 
 	// 1. Setup the Axiom handler for apex.

--- a/examples/ingestfile/main.go
+++ b/examples/ingestfile/main.go
@@ -12,7 +12,8 @@ import (
 )
 
 func main() {
-	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` and `AXIOM_DATASET` for Axiom Cloud.
+	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` (when using a personal token) and
+	// `AXIOM_DATASET` for Axiom Cloud.
 	// Export `AXIOM_URL`, `AXIOM_TOKEN` and `AXIOM_DATASET` for Axiom Selfhost.
 
 	dataset := os.Getenv("AXIOM_DATASET")

--- a/examples/logrus/main.go
+++ b/examples/logrus/main.go
@@ -10,7 +10,8 @@ import (
 )
 
 func main() {
-	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` and `AXIOM_DATASET` for Axiom Cloud.
+	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` (when using a personal token) and
+	// `AXIOM_DATASET` for Axiom Cloud.
 	// Export `AXIOM_URL`, `AXIOM_TOKEN` and `AXIOM_DATASET` for Axiom Selfhost.
 
 	// 1. Setup the Axiom hook for logrus.

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -13,7 +13,8 @@ import (
 )
 
 func main() {
-	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` and `AXIOM_DATASET` for Axiom Cloud.
+	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` (when using a personal token) and
+	// `AXIOM_DATASET` for Axiom Cloud.
 	// Export `AXIOM_URL`, `AXIOM_TOKEN` and `AXIOM_DATASET` for Axiom Selfhost.
 
 	dataset := os.Getenv("AXIOM_DATASET")

--- a/examples/zap/main.go
+++ b/examples/zap/main.go
@@ -10,7 +10,8 @@ import (
 )
 
 func main() {
-	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` and `AXIOM_DATASET` for Axiom Cloud.
+	// Export `AXIOM_TOKEN`, `AXIOM_ORG_ID` (when using a personal token) and
+	// `AXIOM_DATASET` for Axiom Cloud.
 	// Export `AXIOM_URL`, `AXIOM_TOKEN` and `AXIOM_DATASET` for Axiom Selfhost.
 
 	// 1. Setup the Axiom core for zap.


### PR DESCRIPTION
* Ignore the organization id when using an ingest token
* This changes some tests as the order in which the options are checked has changed. Thus, a different error is raised in some cases. But I prefer the new order since pointing out a missing access token is more obvious than pointing out a missing organizatio id.
