### PR TITLE
Support signing keys for organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ using Axiom Cloud. The organization id can be omitted in case an ingest token is
 used.
 
 The access token can be a personal token retrieved from the users profile page,
-an ingest token retrieved from the settings of the Axiom deployment or an API
-token.
+an ingest token retrieved from the settings page of the Axiom deployment or an
+API token.
 
 The personal access token grants access to all resources available to the user
 on his behalf.

--- a/axiom/axiom_integration_test.go
+++ b/axiom/axiom_integration_test.go
@@ -22,7 +22,7 @@ func TestValidateCredentials(t *testing.T) {
 	os.Setenv("AXIOM_URL", deploymentURL)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	err := axiom.ValidateCredentials(ctx)
 	require.NoError(t, err)

--- a/axiom/client_integration_test.go
+++ b/axiom/client_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"flag"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/stretchr/testify/suite"
@@ -34,6 +35,9 @@ func init() {
 type IntegrationTestSuite struct {
 	suite.Suite
 
+	// Generic properties.
+	isCloud bool
+
 	// Setup once per suite.
 	client      *axiom.Client
 	testUser    *axiom.AuthenticatedUser
@@ -53,6 +57,9 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 	s.suiteCtx, s.suiteCancel = context.WithTimeout(context.Background(), time.Minute)
 
+	if strings.Contains(deploymentURL, "cloud.") {
+		s.isCloud = true
+	}
 	if datasetSuffix == "" {
 		datasetSuffix = "local"
 	}

--- a/axiom/orgs.go
+++ b/axiom/orgs.go
@@ -130,24 +130,9 @@ func (l *License) UnmarshalJSON(b []byte) error {
 type SigningKeys struct {
 	// Primary signing key. Gets rotated to the secondary signing key after
 	// rotation.
-	Primary string `json:"-"`
+	Primary string `json:"primary"`
 	// Secondary signing key. Gets rotated out.
-	Secondary string `json:"-"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler. It is in place to enhance the
-// representation of the signin keys field returned by the server.
-func (sk *SigningKeys) UnmarshalJSON(b []byte) error {
-	localKeys := make(map[string]string, 2)
-
-	if err := json.Unmarshal(b, &localKeys); err != nil {
-		return err
-	}
-
-	sk.Primary = localKeys["primary"]
-	sk.Secondary = localKeys["secondary"]
-
-	return nil
+	Secondary string `json:"secondary"`
 }
 
 // Organization represents an organization. For selfhost deployments, there is

--- a/axiom/orgs.go
+++ b/axiom/orgs.go
@@ -164,6 +164,25 @@ type Organization struct {
 	Version string `json:"metaVersion"`
 }
 
+// UnmarshalJSON implements json.Unmarshaler. It is in place to ignore some
+// fields the server returns.
+func (o *Organization) UnmarshalJSON(b []byte) error {
+	type LocalOrg Organization
+	localOrg := struct {
+		*LocalOrg
+
+		Keys map[string]string `json:"keys"`
+	}{
+		LocalOrg: (*LocalOrg)(o),
+	}
+
+	if err := json.Unmarshal(b, &localOrg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // OrganizationUpdateRequest is a request used to update an organization.
 type OrganizationUpdateRequest struct {
 	// Name of the organization. Restricted to 30 characters.

--- a/axiom/orgs.go
+++ b/axiom/orgs.go
@@ -184,7 +184,7 @@ type Organization struct {
 	License License `json:"license"`
 	// SigningKeys are the signing keys used to sign shared access tokens that
 	// can be used by a third party to run queries on behalf of the
-	// organization. They can be rotated.
+	// organization. Signing keys can be rotated. Only available on Axiom Cloud.
 	SigningKeys SigningKeys `json:"keys"`
 	// CreatedAt is the time the Organization was created.
 	CreatedAt time.Time `json:"metaCreated"`

--- a/axiom/orgs_integration_test.go
+++ b/axiom/orgs_integration_test.go
@@ -42,18 +42,6 @@ func (s *OrganizationsTestSuite) Test() {
 
 	s.Equal(&organization.License, license)
 
-	// Rotate the signing keys on the organization and make sure the new keys
-	// are returned.
-	oldPrimaryKey := organization.SigningKeys.Primary
-	oldSecondaryKey := organization.SigningKeys.Secondary
-	organization, err = s.client.Organizations.RotateSigningKeys(s.ctx, organization.ID)
-	s.Require().NoError(err)
-	s.Require().NotNil(organization)
-
-	s.NotEqual(oldPrimaryKey, organization.SigningKeys.Primary)
-	s.NotEqual(oldSecondaryKey, organization.SigningKeys.Secondary)
-	s.Equal(oldPrimaryKey, organization.SigningKeys.Secondary)
-
 	// Let's update the organization. The name is not changed, we just want to
 	// make sure the call works.
 	// HINT(lukasmalkmus): This only works when the authenticated user is an
@@ -65,4 +53,15 @@ func (s *OrganizationsTestSuite) Test() {
 	// s.Require().NotNil(organization)
 
 	// s.Equal(organizations[0].Name, organization.Name)
+
+	// Rotate the signing keys on the organization and make sure the new keys
+	// are returned.
+	oldPrimaryKey, oldSecondaryKey := organization.SigningKeys.Primary, organization.SigningKeys.Secondary
+	organization, err = s.client.Organizations.RotateSigningKeys(s.ctx, organization.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(organization)
+
+	s.NotEqual(oldPrimaryKey, organization.SigningKeys.Primary)
+	s.NotEqual(oldSecondaryKey, organization.SigningKeys.Secondary)
+	s.Equal(oldPrimaryKey, organization.SigningKeys.Secondary)
 }

--- a/axiom/orgs_integration_test.go
+++ b/axiom/orgs_integration_test.go
@@ -55,13 +55,15 @@ func (s *OrganizationsTestSuite) Test() {
 	// s.Equal(organizations[0].Name, organization.Name)
 
 	// Rotate the signing keys on the organization and make sure the new keys
-	// are returned.
-	oldPrimaryKey, oldSecondaryKey := organization.SigningKeys.Primary, organization.SigningKeys.Secondary
-	organization, err = s.client.Organizations.RotateSigningKeys(s.ctx, organization.ID)
-	s.Require().NoError(err)
-	s.Require().NotNil(organization)
+	// are returned (cloud only).
+	if s.isCloud {
+		oldPrimaryKey, oldSecondaryKey := organization.SigningKeys.Primary, organization.SigningKeys.Secondary
+		organization, err = s.client.Organizations.RotateSigningKeys(s.ctx, organization.ID)
+		s.Require().NoError(err)
+		s.Require().NotNil(organization)
 
-	s.NotEqual(oldPrimaryKey, organization.SigningKeys.Primary)
-	s.NotEqual(oldSecondaryKey, organization.SigningKeys.Secondary)
-	s.Equal(oldPrimaryKey, organization.SigningKeys.Secondary)
+		s.NotEqual(oldPrimaryKey, organization.SigningKeys.Primary)
+		s.NotEqual(oldSecondaryKey, organization.SigningKeys.Secondary)
+		s.Equal(oldPrimaryKey, organization.SigningKeys.Secondary)
+	}
 }

--- a/axiom/orgs_integration_test.go
+++ b/axiom/orgs_integration_test.go
@@ -42,6 +42,18 @@ func (s *OrganizationsTestSuite) Test() {
 
 	s.Equal(&organization.License, license)
 
+	// Rotate the signing keys on the organization and make sure the new keys
+	// are returned.
+	oldPrimaryKey := organization.SigningKeys.Primary
+	oldSecondaryKey := organization.SigningKeys.Secondary
+	organization, err = s.client.Organizations.RotateSigningKeys(s.ctx, organization.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(organization)
+
+	s.NotEqual(oldPrimaryKey, organization.SigningKeys.Primary)
+	s.NotEqual(oldSecondaryKey, organization.SigningKeys.Secondary)
+	s.Equal(oldPrimaryKey, organization.SigningKeys.Secondary)
+
 	// Let's update the organization. The name is not changed, we just want to
 	// make sure the call works.
 	// HINT(lukasmalkmus): This only works when the authenticated user is an
@@ -52,5 +64,5 @@ func (s *OrganizationsTestSuite) Test() {
 	// s.Require().NoError(err)
 	// s.Require().NotNil(organization)
 
-	s.Equal(organizations[0].Name, organization.Name)
+	// s.Equal(organizations[0].Name, organization.Name)
 }

--- a/axiom/orgs_integration_test.go
+++ b/axiom/orgs_integration_test.go
@@ -64,6 +64,7 @@ func (s *OrganizationsTestSuite) Test() {
 
 		s.NotEqual(oldPrimaryKey, organization.SigningKeys.Primary)
 		s.NotEqual(oldSecondaryKey, organization.SigningKeys.Secondary)
+		s.NotEqual(oldSecondaryKey, organization.SigningKeys.Primary)
 		s.Equal(oldPrimaryKey, organization.SigningKeys.Secondary)
 	}
 }

--- a/axiom/orgs_test.go
+++ b/axiom/orgs_test.go
@@ -588,31 +588,3 @@ func TestPlan_String(t *testing.T) {
 		assert.NotContains(t, s, "Plan(")
 	}
 }
-
-func TestSigningKeys_Marshal(t *testing.T) {
-	exp := `{}`
-
-	b, err := json.Marshal(SigningKeys{
-		Primary:   "6205e228-f8ed-4265-bee8-058a9b1091db",
-		Secondary: "cea1675d-acff-44b7-8d33-0a3e03c1c37f",
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, b)
-
-	assert.JSONEq(t, exp, string(b))
-}
-
-func TestSigningKeys_Unmarshal(t *testing.T) {
-	act := SigningKeys{
-		Primary:   "6205e228-f8ed-4265-bee8-058a9b1091db",
-		Secondary: "cea1675d-acff-44b7-8d33-0a3e03c1c37f",
-	}
-	err := json.Unmarshal([]byte(`{
-		"primary": "6205e228-f8ed-4265-bee8-058a9b1091db",
-		"secondary": "cea1675d-acff-44b7-8d33-0a3e03c1c37f"
-	}`), &act)
-	require.NoError(t, err)
-
-	assert.Equal(t, "6205e228-f8ed-4265-bee8-058a9b1091db", act.Primary)
-	assert.Equal(t, "cea1675d-acff-44b7-8d33-0a3e03c1c37f", act.Secondary)
-}

--- a/axiom/orgs_test.go
+++ b/axiom/orgs_test.go
@@ -51,6 +51,10 @@ func TestOrganizationsService_List(t *testing.T) {
 				},
 				Error: "",
 			},
+			SigningKeys: SigningKeys{
+				Primary:   "75bb5815-8459-4b6e-a08f-1eb8058db44e",
+				Secondary: "6205e228-f8ed-4265-bee8-058a9b1091db",
+			},
 			CreatedAt:  mustTimeParse(t, time.RFC3339, "1970-01-01T00:00:00Z"),
 			ModifiedAt: mustTimeParse(t, time.RFC3339, "2021-03-11T13:27:28.501218883Z"),
 			Version:    "1615469248501218883",
@@ -97,7 +101,10 @@ func TestOrganizationsService_List(t *testing.T) {
 					],
 					"error": ""
 				},
-				"keys": null,
+				"keys": {
+				"primary": "75bb5815-8459-4b6e-a08f-1eb8058db44e",
+				"secondary": "6205e228-f8ed-4265-bee8-058a9b1091db"
+			},
 				"metaCreated": "1970-01-01T00:00:00Z",
 				"metaModified": "2021-03-11T13:27:28.501218883Z",
 				"metaVersion": "1615469248501218883"
@@ -152,6 +159,10 @@ func TestOrganizationsService_Get(t *testing.T) {
 			},
 			Error: "",
 		},
+		SigningKeys: SigningKeys{
+			Primary:   "75bb5815-8459-4b6e-a08f-1eb8058db44e",
+			Secondary: "6205e228-f8ed-4265-bee8-058a9b1091db",
+		},
 		CreatedAt:  mustTimeParse(t, time.RFC3339, "1970-01-01T00:00:00Z"),
 		ModifiedAt: mustTimeParse(t, time.RFC3339, "2021-03-11T13:27:28.501218883Z"),
 		Version:    "1615469248501218883",
@@ -196,7 +207,10 @@ func TestOrganizationsService_Get(t *testing.T) {
 				],
 				"error": ""
 			},
-			"keys": null,
+			"keys": {
+				"primary": "75bb5815-8459-4b6e-a08f-1eb8058db44e",
+				"secondary": "6205e228-f8ed-4265-bee8-058a9b1091db"
+			},
 			"metaCreated": "1970-01-01T00:00:00Z",
 			"metaModified": "2021-03-11T13:27:28.501218883Z",
 			"metaVersion": "1615469248501218883"
@@ -311,6 +325,10 @@ func TestOrganizationsService_Update(t *testing.T) {
 			},
 			Error: "",
 		},
+		SigningKeys: SigningKeys{
+			Primary:   "75bb5815-8459-4b6e-a08f-1eb8058db44e",
+			Secondary: "6205e228-f8ed-4265-bee8-058a9b1091db",
+		},
 		CreatedAt:  mustTimeParse(t, time.RFC3339, "1970-01-01T00:00:00Z"),
 		ModifiedAt: mustTimeParse(t, time.RFC3339, "2021-03-11T13:27:28.501218883Z"),
 		Version:    "1615469248501218883",
@@ -356,7 +374,10 @@ func TestOrganizationsService_Update(t *testing.T) {
 				],
 				"error": ""
 			},
-			"keys": null,
+			"keys": {
+				"primary": "75bb5815-8459-4b6e-a08f-1eb8058db44e",
+				"secondary": "6205e228-f8ed-4265-bee8-058a9b1091db"
+			},
 			"metaCreated": "1970-01-01T00:00:00Z",
 			"metaModified": "2021-03-11T13:27:28.501218883Z",
 			"metaVersion": "1615469248501218883"

--- a/axiom/orgs_test.go
+++ b/axiom/orgs_test.go
@@ -97,6 +97,7 @@ func TestOrganizationsService_List(t *testing.T) {
 					],
 					"error": ""
 				},
+				"keys": null,
 				"metaCreated": "1970-01-01T00:00:00Z",
 				"metaModified": "2021-03-11T13:27:28.501218883Z",
 				"metaVersion": "1615469248501218883"
@@ -195,6 +196,7 @@ func TestOrganizationsService_Get(t *testing.T) {
 				],
 				"error": ""
 			},
+			"keys": null,
 			"metaCreated": "1970-01-01T00:00:00Z",
 			"metaModified": "2021-03-11T13:27:28.501218883Z",
 			"metaVersion": "1615469248501218883"
@@ -354,6 +356,7 @@ func TestOrganizationsService_Update(t *testing.T) {
 				],
 				"error": ""
 			},
+			"keys": null,
 			"metaCreated": "1970-01-01T00:00:00Z",
 			"metaModified": "2021-03-11T13:27:28.501218883Z",
 			"metaVersion": "1615469248501218883"

--- a/axiom/version_integration_test.go
+++ b/axiom/version_integration_test.go
@@ -4,7 +4,6 @@
 package axiom_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -25,5 +24,5 @@ func (s *VersionTestSuite) Test() {
 	s.Require().NoError(err)
 	s.Require().NotEmpty(version)
 
-	s.True(strings.HasPrefix(version, "v1."))
+	s.Contains(version, "1.")
 }

--- a/axiom/version_test.go
+++ b/axiom/version_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 func TestVersionService_Get(t *testing.T) {
-	exp := "v1.4.0-20201118T1633+1f878f59d"
+	exp := "1.17.0"
 
 	hf := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 
 		_, err := fmt.Fprint(w, `{
-			"currentVersion": "v1.4.0-20201118T1633+1f878f59d"
+			"currentVersion": "1.17.0"
 		}`)
 		assert.NoError(t, err)
 	}


### PR DESCRIPTION
Properly implement support for the upcoming shared access tokens by accepting the `keys` field.

This fixes https://github.com/axiomhq/axiom-go/runs/4755775103?check_suite_focus=true.