### PR TITLE
Add support for '/_fields' endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 # FUNCTIONS
 # func go-run-tool(name)
-go-run-tool = $(CGO) run -mod=mod $(shell echo $(GOTOOLS) | tr ' ' '\n' | grep -w $1)
+go-run-tool = $(CGO) run $(shell echo $(GOTOOLS) | tr ' ' '\n' | grep -w $1)
 
 .PHONY: all
 all: dep generate fmt lint test ## Run dep, generate, fmt, lint and test

--- a/axiom/apl/format.go
+++ b/axiom/apl/format.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=Format -linecomment -output=format_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=Format -linecomment -output=format_string.go
 
 // Format represents the format of an APL query.
 type Format uint8

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -89,6 +89,9 @@ type Field struct {
 	Hidden bool `json:"hidden"`
 }
 
+// Fields maps a dataset to its fields.
+type Fields map[string][]*Field
+
 // DatasetStat represents the details of the information stored inside a
 // dataset.
 type DatasetStat struct {
@@ -123,10 +126,10 @@ type DatasetStat struct {
 // DatasetInfo represents the details of the information stored inside a dataset
 // including the fields that make up the dataset.
 type DatasetInfo struct {
-	DatasetStat
+	*DatasetStat
 
 	// Fields are the fields of the dataset.
-	Fields []Field `json:"fields"`
+	Fields []*Field `json:"fields"`
 }
 
 // DatasetStats are the statistics of all datasets as well as their aggregated
@@ -268,16 +271,11 @@ func (s *DatasetsService) Stats(ctx context.Context) (*DatasetStats, error) {
 	return res, nil
 }
 
-// Infos is like `Stats()` but with the dataset fields included. It returns
-// detailed statistics about all available datasets.
-//
-// This operation is expenssive and listing the datasets and then retreiving
-// the information of a specific dataset is preferred, when no aggregated
-// statistics across all datasets are needed.
-func (s *DatasetsService) Infos(ctx context.Context) ([]*DatasetInfo, error) {
-	path := s.basePath + "/_info"
+// Fields returns the fields of every dataset.
+func (s *DatasetsService) Fields(ctx context.Context) (Fields, error) {
+	path := s.basePath + "/_fields"
 
-	var res []*DatasetInfo
+	var res Fields
 	if err := s.client.call(ctx, http.MethodGet, path, nil, &res); err != nil {
 		return nil, err
 	}

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -18,7 +18,7 @@ import (
 	"github.com/axiomhq/axiom-go/axiom/query"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=ContentType,ContentEncoding -linecomment -output=datasets_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=ContentType,ContentEncoding -linecomment -output=datasets_string.go
 
 // TimestampField is the default field the server looks for a time to use as
 // ingestion time. If not present, the server will set the ingestion time by

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -275,12 +275,20 @@ func (s *DatasetsService) Stats(ctx context.Context) (*DatasetStats, error) {
 func (s *DatasetsService) Fields(ctx context.Context) (Fields, error) {
 	path := s.basePath + "/_fields"
 
-	var res Fields
+	var res []struct {
+		DatasetName string   `json:"datasetName"`
+		Fields      []*Field `json:"fields"`
+	}
 	if err := s.client.call(ctx, http.MethodGet, path, nil, &res); err != nil {
 		return nil, err
 	}
 
-	return res, nil
+	resMap := make(Fields, len(res))
+	for _, fieldSet := range res {
+		resMap[fieldSet.DatasetName] = fieldSet.Fields
+	}
+
+	return resMap, nil
 }
 
 // List all available datasets.

--- a/axiom/datasets_integration_test.go
+++ b/axiom/datasets_integration_test.go
@@ -325,8 +325,9 @@ func (s *DatasetsTestSuite) Test() {
 		s.Require().NoError(optsErr)
 	}()
 
-	// Give the server some time to store the queries.
-	time.Sleep(time.Second)
+	// Give the server some time to store the queries as they are processed
+	// asynchronously.
+	time.Sleep(time.Second * 15)
 
 	historyQuery, err := s.client.Datasets.History(s.ctx, queryResult.SavedQueryID)
 	s.Require().NoError(err)

--- a/axiom/datasets_integration_test.go
+++ b/axiom/datasets_integration_test.go
@@ -194,19 +194,18 @@ func (s *DatasetsTestSuite) Test() {
 	s.EqualValues(8, datasetInfo.NumEvents)
 	s.NotEmpty(datasetInfo.Fields)
 
-	// Get the stats of all datasets and make sure our dataset info is included
-	// in that list.
+	// Get the statistics of all datasets.
 	datasetStats, err := s.client.Datasets.Stats(s.ctx)
 	s.Require().NoError(err)
 	s.Require().NotNil(datasetStats)
 
-	var contains bool
-	for _, stat := range datasetStats.Datasets {
-		if contains = stat.Name == dataset.Name; contains {
-			break
-		}
-	}
-	s.True(contains, "stats do not contain the dataset created for this test")
+	// Get the infos of all datasets and make sure our dataset info is included
+	// in that list.
+	datasetInfos, err := s.client.Datasets.Infos(s.ctx)
+	s.Require().NoError(err)
+	s.Require().NotNil(datasetInfos)
+
+	s.Contains(datasetInfos, datasetInfo, "infos do not contain the dataset created for this test")
 
 	// Update a field of our dataset.
 	field, err := s.client.Datasets.UpdateField(s.ctx, s.dataset.ID, "response", axiom.FieldUpdateRequest{

--- a/axiom/datasets_integration_test.go
+++ b/axiom/datasets_integration_test.go
@@ -199,13 +199,15 @@ func (s *DatasetsTestSuite) Test() {
 	s.Require().NoError(err)
 	s.Require().NotNil(datasetStats)
 
-	// Get the infos of all datasets and make sure our dataset info is included
-	// in that list.
-	datasetInfos, err := s.client.Datasets.Infos(s.ctx)
+	// Get the fields of all datasets and make sure the fields of our dataset
+	// info match those.
+	datasetFields, err := s.client.Datasets.Fields(s.ctx)
 	s.Require().NoError(err)
-	s.Require().NotNil(datasetInfos)
+	s.Require().NotNil(datasetFields)
 
-	s.Contains(datasetInfos, datasetInfo, "infos do not contain the dataset created for this test")
+	if fields := datasetFields[dataset.Name]; s.NotNil(fields, "no fields for dataset %s", dataset.Name) {
+		s.Equal(datasetInfo.Fields, fields, "dataset info fields do not match dataset %s entry in the global list of dataset fields", dataset.Name)
+	}
 
 	// Update a field of our dataset.
 	field, err := s.client.Datasets.UpdateField(s.ctx, s.dataset.ID, "response", axiom.FieldUpdateRequest{

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -287,112 +287,80 @@ func TestDatasetsService_Stats(t *testing.T) {
 	assert.Equal(t, exp, res)
 }
 
-func TestDatasetsService_Infos(t *testing.T) {
-	exp := []*DatasetInfo{
-		{
-			DatasetStat: DatasetStat{
-				Name:                 "test",
-				NumBlocks:            1,
-				NumEvents:            68459,
-				NumFields:            8,
-				InputBytes:           10383386,
-				InputBytesHuman:      "10 MB",
-				CompressedBytes:      2509224,
-				CompressedBytesHuman: "2.5 MB",
-				MinTime:              mustTimeParse(t, time.RFC3339, "2020-11-17T22:30:59Z"),
-				MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
-				CreatedBy:            "f83e245a-afdc-47ad-a765-4addd1994321",
-				CreatedAt:            mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
+func TestDatasetsService_Fields(t *testing.T) {
+	exp := Fields{
+		"test": []*Field{
+			{
+				Name:        "_sysTime",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
 			},
-			Fields: []Field{
-				{
-					Name:        "_sysTime",
-					Description: "",
-					Type:        "integer",
-					Unit:        "",
-					Hidden:      false,
-				},
-				{
-					Name:        "_time",
-					Description: "",
-					Type:        "integer",
-					Unit:        "",
-					Hidden:      false,
-				},
-				{
-					Name:        "path",
-					Description: "",
-					Type:        "string",
-					Unit:        "",
-					Hidden:      false,
-				},
-				{
-					Name:        "size",
-					Description: "",
-					Type:        "integer",
-					Unit:        "",
-					Hidden:      false,
-				},
-				{
-					Name:        "status",
-					Description: "",
-					Type:        "integer",
-					Unit:        "",
-					Hidden:      false,
-				},
+			{
+				Name:        "_time",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
+			},
+			{
+				Name:        "path",
+				Description: "",
+				Type:        "string",
+				Unit:        "",
+				Hidden:      false,
+			},
+			{
+				Name:        "size",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
+			},
+			{
+				Name:        "status",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
 			},
 		},
-		{
-			DatasetStat: DatasetStat{
-				Name:                 "test1",
-				NumBlocks:            1,
-				NumEvents:            68459,
-				NumFields:            8,
-				InputBytes:           10383386,
-				InputBytesHuman:      "10 MB",
-				CompressedBytes:      2509224,
-				CompressedBytesHuman: "2.5 MB",
-				MinTime:              mustTimeParse(t, time.RFC3339, "2020-11-17T22:30:59Z"),
-				MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
-				CreatedBy:            "f83e245a-afdc-47ad-a765-4addd1994321",
-				CreatedAt:            mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
+		"test1": []*Field{
+			{
+				Name:        "_sysTime",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
 			},
-			Fields: []Field{
-				{
-					Name:        "_sysTime",
-					Description: "",
-					Type:        "integer",
-					Unit:        "",
-					Hidden:      false,
-				},
-				{
-					Name:        "_time",
-					Description: "",
-					Type:        "integer",
-					Unit:        "",
-					Hidden:      false,
-				},
-				{
-					Name:        "path",
-					Description: "",
-					Type:        "string",
-					Unit:        "",
-					Hidden:      false,
-				},
-				{
-					Name:        "size",
-					Description: "",
-					Type:        "integer",
-					Unit:        "",
-					Hidden:      false,
-				},
-				{
-					Name:        "status",
-					Description: "",
-					Type:        "integer",
-					Unit:        "",
-					Hidden:      false,
-				},
+			{
+				Name:        "_time",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
+			},
+			{
+				Name:        "path",
+				Description: "",
+				Type:        "string",
+				Unit:        "",
+				Hidden:      false,
+			},
+			{
+				Name:        "size",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
+			},
+			{
+				Name:        "status",
+				Description: "",
+				Type:        "integer",
+				Unit:        "",
+				Hidden:      false,
 			},
 		},
 	}
@@ -400,117 +368,89 @@ func TestDatasetsService_Infos(t *testing.T) {
 	hf := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 
-		_, err := fmt.Fprint(w, `[
-			{
-				"name": "test",
-				"numBlocks": 1,
-				"numEvents": 68459,
-				"numFields": 8,
-				"inputBytes": 10383386,
-				"inputBytesHuman": "10 MB",
-				"compressedBytes": 2509224,
-				"compressedBytesHuman": "2.5 MB",
-				"minTime": "2020-11-17T22:30:59Z",
-				"maxTime": "2020-11-18T17:31:55Z",
-				"fields": [
-					{
-						"name": "_sysTime",
-						"type": "integer",
-						"unit": "",
-						"hidden": false,
-						"description": ""
-					},
-					{
-						"name": "_time",
-						"type": "integer",
-						"unit": "",
-						"hidden": false,
-						"description": ""
-					},
-					{
-						"name": "path",
-						"type": "string",
-						"unit": "",
-						"hidden": false,
-						"description": ""
-					},
-					{
-						"name": "size",
-						"type": "integer",
-						"unit": "",
-						"hidden": false,
-						"description": ""
-					},
-					{
-						"name": "status",
-						"type": "integer",
-						"unit": "",
-						"hidden": false,
-						"description": ""
-					}
-				],
-				"who": "f83e245a-afdc-47ad-a765-4addd1994321",
-				"created": "2020-11-18T21:30:20.623322799Z"
-			},
-			{
-				"name": "test1",
-				"numBlocks": 1,
-				"numEvents": 68459,
-				"numFields": 8,
-				"inputBytes": 10383386,
-				"inputBytesHuman": "10 MB",
-				"compressedBytes": 2509224,
-				"compressedBytesHuman": "2.5 MB",
-				"minTime": "2020-11-17T22:30:59Z",
-				"maxTime": "2020-11-18T17:31:55Z",
-				"fields": [
-					{
-						"name": "_sysTime",
-						"type": "integer",
-						"unit": "",
-						"hidden": false,
-						"description": ""
-					},
-					{
-						"name": "_time",
-						"type": "integer",
-						"unit": "",
-						"hidden": false,
-						"description": ""
-					},
-					{
-						"name": "path",
-						"type": "string",
-						"unit": "",
-						"hidden": false,
-						"description": ""
-					},
-					{
-						"name": "size",
-						"type": "integer",
-						"unit": "",
-						"hidden": false,
-						"description": ""
-					},
-					{
-						"name": "status",
-						"type": "integer",
-						"unit": "",
-						"hidden": false,
-						"description": ""
-					}
-				],
-				"who": "f83e245a-afdc-47ad-a765-4addd1994321",
-				"created": "2020-11-18T21:30:20.623322799Z"
-			}
-		]`)
+		_, err := fmt.Fprint(w, `{
+			"test": [
+				{
+					"name": "_sysTime",
+					"type": "integer",
+					"unit": "",
+					"hidden": false,
+					"description": ""
+				},
+				{
+					"name": "_time",
+					"type": "integer",
+					"unit": "",
+					"hidden": false,
+					"description": ""
+				},
+				{
+					"name": "path",
+					"type": "string",
+					"unit": "",
+					"hidden": false,
+					"description": ""
+				},
+				{
+					"name": "size",
+					"type": "integer",
+					"unit": "",
+					"hidden": false,
+					"description": ""
+				},
+				{
+					"name": "status",
+					"type": "integer",
+					"unit": "",
+					"hidden": false,
+					"description": ""
+				}
+			],
+			"test1": [
+				{
+					"name": "_sysTime",
+					"type": "integer",
+					"unit": "",
+					"hidden": false,
+					"description": ""
+				},
+				{
+					"name": "_time",
+					"type": "integer",
+					"unit": "",
+					"hidden": false,
+					"description": ""
+				},
+				{
+					"name": "path",
+					"type": "string",
+					"unit": "",
+					"hidden": false,
+					"description": ""
+				},
+				{
+					"name": "size",
+					"type": "integer",
+					"unit": "",
+					"hidden": false,
+					"description": ""
+				},
+				{
+					"name": "status",
+					"type": "integer",
+					"unit": "",
+					"hidden": false,
+					"description": ""
+				}
+			]
+		}`)
 		assert.NoError(t, err)
 	}
 
-	client, teardown := setup(t, "/api/v1/datasets/_info", hf)
+	client, teardown := setup(t, "/api/v1/datasets/_fields", hf)
 	defer teardown()
 
-	res, err := client.Datasets.Infos(context.Background())
+	res, err := client.Datasets.Fields(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, exp, res)
@@ -700,7 +640,7 @@ func TestDatasetsService_Delete(t *testing.T) {
 
 func TestDatasetsService_Info(t *testing.T) {
 	exp := &DatasetInfo{
-		DatasetStat: DatasetStat{
+		DatasetStat: &DatasetStat{
 			Name:                 "test",
 			NumBlocks:            1,
 			NumEvents:            68459,
@@ -714,7 +654,7 @@ func TestDatasetsService_Info(t *testing.T) {
 			CreatedBy:            "f83e245a-afdc-47ad-a765-4addd1994321",
 			CreatedAt:            mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
 		},
-		Fields: []Field{
+		Fields: []*Field{
 			{
 				Name:        "_sysTime",
 				Description: "",

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -368,82 +368,86 @@ func TestDatasetsService_Fields(t *testing.T) {
 	hf := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 
-		_, err := fmt.Fprint(w, `{
-			"test": [
-				{
-					"name": "_sysTime",
-					"type": "integer",
-					"unit": "",
-					"hidden": false,
-					"description": ""
-				},
-				{
-					"name": "_time",
-					"type": "integer",
-					"unit": "",
-					"hidden": false,
-					"description": ""
-				},
-				{
-					"name": "path",
-					"type": "string",
-					"unit": "",
-					"hidden": false,
-					"description": ""
-				},
-				{
-					"name": "size",
-					"type": "integer",
-					"unit": "",
-					"hidden": false,
-					"description": ""
-				},
-				{
-					"name": "status",
-					"type": "integer",
-					"unit": "",
-					"hidden": false,
-					"description": ""
-				}
-			],
-			"test1": [
-				{
-					"name": "_sysTime",
-					"type": "integer",
-					"unit": "",
-					"hidden": false,
-					"description": ""
-				},
-				{
-					"name": "_time",
-					"type": "integer",
-					"unit": "",
-					"hidden": false,
-					"description": ""
-				},
-				{
-					"name": "path",
-					"type": "string",
-					"unit": "",
-					"hidden": false,
-					"description": ""
-				},
-				{
-					"name": "size",
-					"type": "integer",
-					"unit": "",
-					"hidden": false,
-					"description": ""
-				},
-				{
-					"name": "status",
-					"type": "integer",
-					"unit": "",
-					"hidden": false,
-					"description": ""
-				}
-			]
-		}`)
+		_, err := fmt.Fprint(w, `[
+			{
+				"datasetName": "test",
+				"fields": [{
+						"name": "_sysTime",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "_time",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "path",
+						"type": "string",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "size",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "status",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					}
+				]
+			},
+			{
+				"datasetName": "test1",
+				"fields": [{
+						"name": "_sysTime",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "_time",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "path",
+						"type": "string",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "size",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "status",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					}
+				]
+			}
+		]`)
 		assert.NoError(t, err)
 	}
 

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -196,7 +196,7 @@ var expAPLQueryRes = &apl.Result{
 
 func TestDatasetsService_Stats(t *testing.T) {
 	exp := &DatasetStats{
-		Datasets: []*DatasetInfo{
+		Datasets: []*DatasetStat{
 			{
 				Name:                 "test",
 				NumBlocks:            1,
@@ -208,45 +208,8 @@ func TestDatasetsService_Stats(t *testing.T) {
 				CompressedBytesHuman: "2.5 MB",
 				MinTime:              mustTimeParse(t, time.RFC3339, "2020-11-17T22:30:59Z"),
 				MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
-				Fields: []Field{
-					{
-						Name:        "_sysTime",
-						Description: "",
-						Type:        "integer",
-						Unit:        "",
-						Hidden:      false,
-					},
-					{
-						Name:        "_time",
-						Description: "",
-						Type:        "integer",
-						Unit:        "",
-						Hidden:      false,
-					},
-					{
-						Name:        "path",
-						Description: "",
-						Type:        "string",
-						Unit:        "",
-						Hidden:      false,
-					},
-					{
-						Name:        "size",
-						Description: "",
-						Type:        "integer",
-						Unit:        "",
-						Hidden:      false,
-					},
-					{
-						Name:        "status",
-						Description: "",
-						Type:        "integer",
-						Unit:        "",
-						Hidden:      false,
-					},
-				},
-				CreatedBy: "f83e245a-afdc-47ad-a765-4addd1994321",
-				CreatedAt: mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
+				CreatedBy:            "f83e245a-afdc-47ad-a765-4addd1994321",
+				CreatedAt:            mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
 			},
 			{
 				Name:                 "test1",
@@ -259,45 +222,8 @@ func TestDatasetsService_Stats(t *testing.T) {
 				CompressedBytesHuman: "2.5 MB",
 				MinTime:              mustTimeParse(t, time.RFC3339, "2020-11-17T22:30:59Z"),
 				MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
-				Fields: []Field{
-					{
-						Name:        "_sysTime",
-						Description: "",
-						Type:        "integer",
-						Unit:        "",
-						Hidden:      false,
-					},
-					{
-						Name:        "_time",
-						Description: "",
-						Type:        "integer",
-						Unit:        "",
-						Hidden:      false,
-					},
-					{
-						Name:        "path",
-						Description: "",
-						Type:        "string",
-						Unit:        "",
-						Hidden:      false,
-					},
-					{
-						Name:        "size",
-						Description: "",
-						Type:        "integer",
-						Unit:        "",
-						Hidden:      false,
-					},
-					{
-						Name:        "status",
-						Description: "",
-						Type:        "integer",
-						Unit:        "",
-						Hidden:      false,
-					},
-				},
-				CreatedBy: "f83e245a-afdc-47ad-a765-4addd1994321",
-				CreatedAt: mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
+				CreatedBy:            "f83e245a-afdc-47ad-a765-4addd1994321",
+				CreatedAt:            mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
 			},
 		},
 		NumBlocks:            2,
@@ -324,43 +250,6 @@ func TestDatasetsService_Stats(t *testing.T) {
 					"compressedBytesHuman": "2.5 MB",
 					"minTime": "2020-11-17T22:30:59Z",
 					"maxTime": "2020-11-18T17:31:55Z",
-					"fields": [
-						{
-							"name": "_sysTime",
-							"type": "integer",
-							"unit": "",
-            				"hidden": false,
-            				"description": ""
-						},
-						{
-							"name": "_time",
-							"type": "integer",
-							"unit": "",
-            				"hidden": false,
-            				"description": ""
-						},
-						{
-							"name": "path",
-							"type": "string",
-							"unit": "",
-            				"hidden": false,
-            				"description": ""
-						},
-						{
-							"name": "size",
-							"type": "integer",
-							"unit": "",
-            				"hidden": false,
-            				"description": ""
-						},
-						{
-							"name": "status",
-							"type": "integer",
-							"unit": "",
-            				"hidden": false,
-            				"description": ""
-						}
-					],
 					"who": "f83e245a-afdc-47ad-a765-4addd1994321",
 					"created": "2020-11-18T21:30:20.623322799Z"
 				},
@@ -375,43 +264,6 @@ func TestDatasetsService_Stats(t *testing.T) {
 					"compressedBytesHuman": "2.5 MB",
 					"minTime": "2020-11-17T22:30:59Z",
 					"maxTime": "2020-11-18T17:31:55Z",
-					"fields": [
-						{
-							"name": "_sysTime",
-							"type": "integer",
-							"unit": "",
-            				"hidden": false,
-            				"description": ""
-						},
-						{
-							"name": "_time",
-							"type": "integer",
-							"unit": "",
-            				"hidden": false,
-            				"description": ""
-						},
-						{
-							"name": "path",
-							"type": "string",
-							"unit": "",
-            				"hidden": false,
-            				"description": ""
-						},
-						{
-							"name": "size",
-							"type": "integer",
-							"unit": "",
-            				"hidden": false,
-            				"description": ""
-						},
-						{
-							"name": "status",
-							"type": "integer",
-							"unit": "",
-            				"hidden": false,
-            				"description": ""
-						}
-					],
 					"who": "f83e245a-afdc-47ad-a765-4addd1994321",
 					"created": "2020-11-18T21:30:20.623322799Z"
 				}
@@ -430,6 +282,235 @@ func TestDatasetsService_Stats(t *testing.T) {
 	defer teardown()
 
 	res, err := client.Datasets.Stats(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, exp, res)
+}
+
+func TestDatasetsService_Infos(t *testing.T) {
+	exp := []*DatasetInfo{
+		{
+			DatasetStat: DatasetStat{
+				Name:                 "test",
+				NumBlocks:            1,
+				NumEvents:            68459,
+				NumFields:            8,
+				InputBytes:           10383386,
+				InputBytesHuman:      "10 MB",
+				CompressedBytes:      2509224,
+				CompressedBytesHuman: "2.5 MB",
+				MinTime:              mustTimeParse(t, time.RFC3339, "2020-11-17T22:30:59Z"),
+				MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
+				CreatedBy:            "f83e245a-afdc-47ad-a765-4addd1994321",
+				CreatedAt:            mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
+			},
+			Fields: []Field{
+				{
+					Name:        "_sysTime",
+					Description: "",
+					Type:        "integer",
+					Unit:        "",
+					Hidden:      false,
+				},
+				{
+					Name:        "_time",
+					Description: "",
+					Type:        "integer",
+					Unit:        "",
+					Hidden:      false,
+				},
+				{
+					Name:        "path",
+					Description: "",
+					Type:        "string",
+					Unit:        "",
+					Hidden:      false,
+				},
+				{
+					Name:        "size",
+					Description: "",
+					Type:        "integer",
+					Unit:        "",
+					Hidden:      false,
+				},
+				{
+					Name:        "status",
+					Description: "",
+					Type:        "integer",
+					Unit:        "",
+					Hidden:      false,
+				},
+			},
+		},
+		{
+			DatasetStat: DatasetStat{
+				Name:                 "test1",
+				NumBlocks:            1,
+				NumEvents:            68459,
+				NumFields:            8,
+				InputBytes:           10383386,
+				InputBytesHuman:      "10 MB",
+				CompressedBytes:      2509224,
+				CompressedBytesHuman: "2.5 MB",
+				MinTime:              mustTimeParse(t, time.RFC3339, "2020-11-17T22:30:59Z"),
+				MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
+				CreatedBy:            "f83e245a-afdc-47ad-a765-4addd1994321",
+				CreatedAt:            mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
+			},
+			Fields: []Field{
+				{
+					Name:        "_sysTime",
+					Description: "",
+					Type:        "integer",
+					Unit:        "",
+					Hidden:      false,
+				},
+				{
+					Name:        "_time",
+					Description: "",
+					Type:        "integer",
+					Unit:        "",
+					Hidden:      false,
+				},
+				{
+					Name:        "path",
+					Description: "",
+					Type:        "string",
+					Unit:        "",
+					Hidden:      false,
+				},
+				{
+					Name:        "size",
+					Description: "",
+					Type:        "integer",
+					Unit:        "",
+					Hidden:      false,
+				},
+				{
+					Name:        "status",
+					Description: "",
+					Type:        "integer",
+					Unit:        "",
+					Hidden:      false,
+				},
+			},
+		},
+	}
+
+	hf := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+
+		_, err := fmt.Fprint(w, `[
+			{
+				"name": "test",
+				"numBlocks": 1,
+				"numEvents": 68459,
+				"numFields": 8,
+				"inputBytes": 10383386,
+				"inputBytesHuman": "10 MB",
+				"compressedBytes": 2509224,
+				"compressedBytesHuman": "2.5 MB",
+				"minTime": "2020-11-17T22:30:59Z",
+				"maxTime": "2020-11-18T17:31:55Z",
+				"fields": [
+					{
+						"name": "_sysTime",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "_time",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "path",
+						"type": "string",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "size",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "status",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					}
+				],
+				"who": "f83e245a-afdc-47ad-a765-4addd1994321",
+				"created": "2020-11-18T21:30:20.623322799Z"
+			},
+			{
+				"name": "test1",
+				"numBlocks": 1,
+				"numEvents": 68459,
+				"numFields": 8,
+				"inputBytes": 10383386,
+				"inputBytesHuman": "10 MB",
+				"compressedBytes": 2509224,
+				"compressedBytesHuman": "2.5 MB",
+				"minTime": "2020-11-17T22:30:59Z",
+				"maxTime": "2020-11-18T17:31:55Z",
+				"fields": [
+					{
+						"name": "_sysTime",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "_time",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "path",
+						"type": "string",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "size",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					},
+					{
+						"name": "status",
+						"type": "integer",
+						"unit": "",
+						"hidden": false,
+						"description": ""
+					}
+				],
+				"who": "f83e245a-afdc-47ad-a765-4addd1994321",
+				"created": "2020-11-18T21:30:20.623322799Z"
+			}
+		]`)
+		assert.NoError(t, err)
+	}
+
+	client, teardown := setup(t, "/api/v1/datasets/_info", hf)
+	defer teardown()
+
+	res, err := client.Datasets.Infos(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, exp, res)
@@ -619,16 +700,20 @@ func TestDatasetsService_Delete(t *testing.T) {
 
 func TestDatasetsService_Info(t *testing.T) {
 	exp := &DatasetInfo{
-		Name:                 "test",
-		NumBlocks:            1,
-		NumEvents:            68459,
-		NumFields:            8,
-		InputBytes:           10383386,
-		InputBytesHuman:      "10 MB",
-		CompressedBytes:      2509224,
-		CompressedBytesHuman: "2.5 MB",
-		MinTime:              mustTimeParse(t, time.RFC3339, "2020-11-17T22:30:59Z"),
-		MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
+		DatasetStat: DatasetStat{
+			Name:                 "test",
+			NumBlocks:            1,
+			NumEvents:            68459,
+			NumFields:            8,
+			InputBytes:           10383386,
+			InputBytesHuman:      "10 MB",
+			CompressedBytes:      2509224,
+			CompressedBytesHuman: "2.5 MB",
+			MinTime:              mustTimeParse(t, time.RFC3339, "2020-11-17T22:30:59Z"),
+			MaxTime:              mustTimeParse(t, time.RFC3339, "2020-11-18T17:31:55Z"),
+			CreatedBy:            "f83e245a-afdc-47ad-a765-4addd1994321",
+			CreatedAt:            mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
+		},
 		Fields: []Field{
 			{
 				Name:        "_sysTime",
@@ -666,8 +751,6 @@ func TestDatasetsService_Info(t *testing.T) {
 				Hidden:      false,
 			},
 		},
-		CreatedBy: "f83e245a-afdc-47ad-a765-4addd1994321",
-		CreatedAt: mustTimeParse(t, time.RFC3339Nano, "2020-11-18T21:30:20.623322799Z"),
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {

--- a/axiom/monitors.go
+++ b/axiom/monitors.go
@@ -10,7 +10,7 @@ import (
 	"github.com/axiomhq/axiom-go/axiom/query"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=Comparison -linecomment -output=monitors_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=Comparison -linecomment -output=monitors_string.go
 
 // Comparison represents a comparison operation for a monitor. A monitor acts on
 // the result of comparing a query result with a threshold.

--- a/axiom/notifiers.go
+++ b/axiom/notifiers.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=Type -linecomment -output=notifiers_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=Type -linecomment -output=notifiers_string.go
 
 // Type represents the type of a notifier.
 type Type uint8

--- a/axiom/orgs.go
+++ b/axiom/orgs.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=Plan -linecomment -output=orgs_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=Plan -linecomment -output=orgs_string.go
 
 // Plan represents the plan of a deployment or organization.
 type Plan uint8

--- a/axiom/query/aggregation.go
+++ b/axiom/query/aggregation.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=AggregationOp -linecomment -output=aggregation_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=AggregationOp -linecomment -output=aggregation_string.go
 
 // An AggregationOp can be applied on queries to aggrgate based on different
 // conditions.

--- a/axiom/query/filter.go
+++ b/axiom/query/filter.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=FilterOp -linecomment -output=filter_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=FilterOp -linecomment -output=filter_string.go
 
 // A FilterOp can be applied on queries to filter based on different conditions.
 type FilterOp uint8

--- a/axiom/query/kind.go
+++ b/axiom/query/kind.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=Kind -linecomment -output=kind_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=Kind -linecomment -output=kind_string.go
 
 // Kind represents the role of a query.
 type Kind uint8

--- a/axiom/query/result.go
+++ b/axiom/query/result.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=MessageCode,MessagePriority -linecomment -output=result_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=MessageCode,MessagePriority -linecomment -output=result_string.go
 
 // MessageCode represents the code of a message associated with a query.
 type MessageCode uint8

--- a/axiom/starred.go
+++ b/axiom/starred.go
@@ -9,7 +9,7 @@ import (
 	"github.com/axiomhq/axiom-go/axiom/query"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=OwnerKind -linecomment -output=starred_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=OwnerKind -linecomment -output=starred_string.go
 
 // OwnerKind represents the kind of a starred queries owner.
 type OwnerKind uint8

--- a/axiom/tokens.go
+++ b/axiom/tokens.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=Permission -linecomment -output=tokens_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=Permission -linecomment -output=tokens_string.go
 
 // Permission of an API token.
 type Permission uint8

--- a/axiom/users.go
+++ b/axiom/users.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-//go:generate go run -mod=mod golang.org/x/tools/cmd/stringer -type=UserRole -linecomment -output=users_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=UserRole -linecomment -output=users_string.go
 
 // UserRole represents the role of a user.
 type UserRole uint8


### PR DESCRIPTION
<strike>This has long been outstanding but went unnoticed: There has been a new `/_info` endpoint for a while, now. This is basically a list of dataset infos as returned by a normal call to `:id/info`. The `/_stats` call shares the same response model, apart from omitting the fields so this was never an issue. But it is desirable to have the separate call available.

I was able to refactor this slightly to compensate for the missing fields and enhanced the documentation along the way.</strike>

<strike>As explained by @mhr3, the `/_info` endpoint is deprecated and - after discussion - will be replaced by `/_fields`. The rest of the information that could be obtained through `/_info` is still available through `/_stats`. The recent commit accounts for that change but I kept the improvements to the `DatasetInfo` and `DatasetStats` types as well as the documentation improvements. Until the change is live, this PR will remain in draft status.</strike>

After more evaluation, there will be one new endpoint introduced with this PR: `/_fields`, for retrieving fields of all datasets of a deployment. However, in addition, `/_info` is deleted as it is essentially the infomration provided by `/_fields` plus some information only useful for the frontend but not actual costumers. The recent commit accounts for that change but I kept the improvements to the `DatasetInfo` and `DatasetStats` types as well as the documentation improvements. Until the change is live, this PR will remain in draft status.

Needs #106.