### PR TITLE
Allow explicit configuration with api token

### DIFF
--- a/axiom/client.go
+++ b/axiom/client.go
@@ -182,14 +182,15 @@ func (c *Client) populateClientFromEnvironment() (err error) {
 	}
 
 	// When the organization ID is not set, use `AXIOM_ORG_ID`. In case the url
-	// is the Axiom Cloud url and the access token is not a personal token, the
+	// is the Axiom Cloud url and the access token is a personal token, the
 	// organization ID is explicitly required and an error is returned, if it is
 	// not set.
 	cloudURLSetByOption := c.baseURL != nil && c.baseURL.String() == CloudURL
 	cloudURLSetByEnvironment := deploymentURL == CloudURL
 	cloudURLSet := cloudURLSetByOption || cloudURLSetByEnvironment
+	isAPIToken := IsAPIToken(c.accessToken) || IsAPIToken(accessToken)
 	isPersonalToken := IsPersonalToken(c.accessToken) || IsPersonalToken(accessToken)
-	if c.orgID == "" {
+	if c.orgID == "" && !isAPIToken {
 		if (orgID == "" && cloudURLSet && isPersonalToken) || (c.noEnv && cloudURLSet) {
 			return ErrMissingOrganizationID
 		}

--- a/axiom/client_test.go
+++ b/axiom/client_test.go
@@ -189,6 +189,14 @@ func TestNewClient(t *testing.T) {
 			},
 			err: ErrMissingAccessToken,
 		},
+		{
+			name: "no environment noEnv, cloudUrl and accessToken option with API token",
+			options: []Option{
+				SetNoEnv(),
+				SetURL(CloudURL),
+				SetAccessToken(apiToken),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
With the recent changes related to the outphasing of ingest tokens, there was an oversight with how we deal with **api** tokens when using the `SetNoEnv()` option. This fixes a case where an error would be returned when no organization ID was provided.

The logic is kinda tricky for something that should actually be simple because it takes into account what kind of Axiom deployment is being used as well as the type of token.