### PR TITLE
Swallow fields meta

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: Cleanup (On Test Failure)
         if: failure()
         run: |
-          go install github.com/axiomhq/cli/cmd/axiom@latest
+          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/latest | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
           axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ matrix.go }}")).id' | xargs -n1 axiom dataset delete -f
       - name: Update Coverage
         if: matrix.update-coverage

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: Cleanup (On Test Failure)
         if: failure()
         run: |
-          go install github.com/axiomhq/cli/cmd/axiom@latest
+          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/latest | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
           axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ matrix.go }}")).id' | xargs -n1 axiom dataset delete -f
       - name: Update Coverage
         if: matrix.update-coverage

--- a/.github/workflows/server_regression.yaml
+++ b/.github/workflows/server_regression.yaml
@@ -48,5 +48,5 @@ jobs:
       - name: Cleanup (On Test Failure)
         if: failure()
         run: |
-          go install github.com/axiomhq/cli/cmd/axiom@latest
+          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/latest | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
           axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ matrix.go }}")).id' | xargs -n1 axiom dataset delete -f

--- a/.github/workflows/test_examples.yaml
+++ b/.github/workflows/test_examples.yaml
@@ -71,7 +71,7 @@ jobs:
           echo "AXIOM_TOKEN=${{ steps.axiom.outputs.token }}" >> $GITHUB_ENV
       - name: Setup
         run: |
-          go install github.com/axiomhq/cli/cmd/axiom@latest
+          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/latest | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
           axiom dataset create -n=$AXIOM_DATASET -d="Axiom Go examples test"
       - name: Setup example
         if: matrix.setup

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -513,7 +513,7 @@ func (s *DatasetsService) Query(ctx context.Context, id string, q query.Query, o
 	var (
 		res struct {
 			query.Result
-			_ interface{} `json:"fieldsMetaMap"` //nolint:govet // HINT(lukasmalkmus): Fine to ignore.
+			FieldsMeta interface{} `json:"fieldsMeta"`
 		}
 		resp *response
 	)
@@ -545,7 +545,7 @@ func (s *DatasetsService) APLQuery(ctx context.Context, raw string, opts apl.Opt
 	var (
 		res struct {
 			apl.Result
-			_ interface{} `json:"fieldsMeta"` //nolint:govet // HINT(lukasmalkmus): Fine to ignore.
+			FieldsMeta interface{} `json:"fieldsMetaMap"`
 		}
 		resp *response
 	)

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -511,7 +511,10 @@ func (s *DatasetsService) Query(ctx context.Context, id string, q query.Query, o
 	}
 
 	var (
-		res  query.Result
+		res struct {
+			query.Result
+			_ interface{} `json:"fieldsMetaMap"` //nolint:govet // HINT(lukasmalkmus): Fine to ignore.
+		}
 		resp *response
 	)
 	if resp, err = s.client.do(req, &res); err != nil {
@@ -519,7 +522,7 @@ func (s *DatasetsService) Query(ctx context.Context, id string, q query.Query, o
 	}
 	res.SavedQueryID = resp.Header.Get("X-Axiom-History-Query-Id")
 
-	return &res, nil
+	return &res.Result, nil
 }
 
 // APLQuery executes the given query specified using the Axiom Processing
@@ -540,7 +543,10 @@ func (s *DatasetsService) APLQuery(ctx context.Context, raw string, opts apl.Opt
 	}
 
 	var (
-		res  apl.Result
+		res struct {
+			apl.Result
+			_ interface{} `json:"fieldsMeta"` //nolint:govet // HINT(lukasmalkmus): Fine to ignore.
+		}
 		resp *response
 	)
 	if resp, err = s.client.do(req, &res); err != nil {
@@ -548,7 +554,7 @@ func (s *DatasetsService) APLQuery(ctx context.Context, raw string, opts apl.Opt
 	}
 	res.SavedQueryID = resp.Header.Get("X-Axiom-History-Query-Id")
 
-	return &res, nil
+	return &res.Result, nil
 }
 
 // DetectContentType detects the content type of an io.Reader's data. The


### PR DESCRIPTION
This PR "swallows" the new `fieldsMeta` and `fieldsMetaMap` response objects. There is no need for them to be supported in this client library, yet. But this PR makes CI green again and documents, that the fields are there but unused.