### PR TITLE
feat(client): extract module info from build info for use in 'User-Agent' header

### DIFF
--- a/axiom/client.go
+++ b/axiom/client.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -121,6 +122,16 @@ func NewClient(options ...Option) (*Client, error) {
 		httpClient: DefaultHTTPClient(),
 
 		limits: make(map[string]Limit),
+	}
+
+	// Try to get module version to include in the user agent.
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/axiomhq/axiom-go" {
+				client.userAgent += fmt.Sprintf("/%s", dep.Version)
+				break
+			}
+		}
 	}
 
 	client.Dashboards = &DashboardsService{client, "/api/v1/dashboards"}


### PR DESCRIPTION
This extracts the module info from the build info of a binary and uses the `axiom-go` module version in the `User-Agent` header.

I tested this manually, haven't figured out how to write a test for this. Tests are still part of this module, so it won't recoginze `axiom-go` as a dependency, even if imported.