### PR TITLE
feat(ci): optimize

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,7 @@ jobs:
         go:
           - 1.17
           - 1.18
+          - ^1.19.0-beta.1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -33,11 +34,16 @@ jobs:
     name: Lint
     needs: gen-diff
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         go:
           - 1.17
           - 1.18
+          - ^1.19.0-beta.1
+        include:
+          - go: ^1.19.0-beta.1
+            experimental: true
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -50,6 +56,7 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         deployment:
@@ -58,10 +65,12 @@ jobs:
         go:
           - 1.17
           - 1.18
+          - ^1.19.0-beta.1
         include:
           - deployment: azure-1-staging
             axiom_url: TESTING_AZURE_1_STAGING_DEPLOYMENT_URL
             axiom_token: TESTING_AZURE_1_STAGING_ACCESS_TOKEN
+            experimental: true
           - deployment: cloud-dev
             axiom_url: TESTING_CLOUD_DEV_DEPLOYMENT_URL
             axiom_token: TESTING_CLOUD_DEV_ACCESS_TOKEN
@@ -69,8 +78,10 @@ jobs:
           - deployment: cloud-dev
             go: 1.17
             update-coverage: true
+          - deployment: cloud-dev
+            go: ^1.19.0-beta.1
+            experimental: true
       max-parallel: 1
-      fail-fast: false
     env:
       AXIOM_URL: ${{ secrets[matrix.axiom_url] }}
       AXIOM_TOKEN: ${{ secrets[matrix.axiom_token] }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,6 +14,7 @@ jobs:
         go:
           - 1.17
           - 1.18
+          - ^1.19.0-beta.1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -38,6 +39,7 @@ jobs:
         go:
           - 1.17
           - 1.18
+          - ^1.19.0-beta.1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -49,6 +51,7 @@ jobs:
     name: Test
     needs: lint
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         deployment:
@@ -57,10 +60,12 @@ jobs:
         go:
           - 1.17
           - 1.18
+          - ^1.19.0-beta.1
         include:
           - deployment: azure-1-staging
             axiom_url: TESTING_AZURE_1_STAGING_DEPLOYMENT_URL
             axiom_token: TESTING_AZURE_1_STAGING_ACCESS_TOKEN
+            experimental: true
           - deployment: cloud-dev
             axiom_url: TESTING_CLOUD_DEV_DEPLOYMENT_URL
             axiom_token: TESTING_CLOUD_DEV_ACCESS_TOKEN
@@ -69,8 +74,10 @@ jobs:
             go: 1.17
             update-coverage: true
             update-goreportcard: true
+          - deployment: cloud-dev
+            go: ^1.19.0-beta.1
+            experimental: true
       max-parallel: 1
-      fail-fast: false
     env:
       AXIOM_URL: ${{ secrets[matrix.axiom_url] }}
       AXIOM_TOKEN: ${{ secrets[matrix.axiom_token] }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
-      - uses: goreleaser/goreleaser-action@v2
+      - uses: goreleaser/goreleaser-action@v3
         with:
           args: release
         env:

--- a/.github/workflows/server_regression.yaml
+++ b/.github/workflows/server_regression.yaml
@@ -9,6 +9,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         deployment:
@@ -17,16 +18,20 @@ jobs:
         go:
           - 1.17
           - 1.18
+          - ^1.19.0-beta.1
         include:
           - deployment: azure-1-staging
             axiom_url: TESTING_AZURE_1_STAGING_DEPLOYMENT_URL
             axiom_token: TESTING_AZURE_1_STAGING_ACCESS_TOKEN
+            experimental: true
           - deployment: cloud-dev
             axiom_url: TESTING_CLOUD_DEV_DEPLOYMENT_URL
             axiom_token: TESTING_CLOUD_DEV_ACCESS_TOKEN
             axiom_org_id: TESTING_CLOUD_DEV_ORG_ID
+          - deployment: cloud-dev
+            go: ^1.19.0-beta.1
+            experimental: true
       max-parallel: 1
-      fail-fast: false
     env:
       AXIOM_URL: ${{ secrets[matrix.axiom_url] }}
       AXIOM_TOKEN: ${{ secrets[matrix.axiom_token] }}


### PR DESCRIPTION
<strike>This PR optimizes CI by delegating caching to the `setup-go@v3` action. as per: https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs. This drops a lot of redundant caching code.</strike>

Apparently, this didn't work as expected. Leaving as is.

It also adds Go 1.19 as "experimental" to test against the upcoming of Go. The `experimental` include also improves how jobs are cancelled to reduce the amount of CI time that is used (and billed).