### PR TITLE
fix(limit): drop faulty rate limiting logic

### DIFF
--- a/axiom/client_options.go
+++ b/axiom/client_options.go
@@ -99,12 +99,3 @@ func SetNoEnv() Option {
 		return nil
 	}
 }
-
-// SetNoLimiting prevents the client from performing client side request
-// limting.
-func SetNoLimiting() Option {
-	return func(c *Client) error {
-		c.noLimiting = true
-		return nil
-	}
-}

--- a/axiom/limit.go
+++ b/axiom/limit.go
@@ -120,8 +120,3 @@ func parseLimitFromHeaders(r *http.Response, headerScope, headerLimit, headerRem
 	}
 	return limit
 }
-
-// limitKey returns a unique key for the limit type and scope combination.
-func limitKey(limitType limitType, limitScope LimitScope) string {
-	return fmt.Sprintf("%s:%s", limitType, limitScope)
-}

--- a/axiom/limit_string.go
+++ b/axiom/limit_string.go
@@ -8,14 +8,14 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[limitRate-1]
+	_ = x[limitIngest-1]
 	_ = x[limitQuery-2]
-	_ = x[limitIngest-3]
+	_ = x[limitRate-3]
 }
 
-const _limitType_name = "ratequeryingest"
+const _limitType_name = "ingestqueryrate"
 
-var _limitType_index = [...]uint8{0, 4, 9, 15}
+var _limitType_index = [...]uint8{0, 6, 11, 15}
 
 func (i limitType) String() string {
 	i -= 1


### PR DESCRIPTION
This PR drops client side rate limiting. As the Axiom service has evolved, different kinds of limits have been introduced and make implementing client-side limiting harder. As we are a service that - by nature - deals with a high volume of incoming data, we decided to not let the client deal with limiting, too, as a faulty limiting logic can prevent the client from sending data (where as the server might not apply the same limit).