### PR TITLE
feat(query): add argmin, argmax and set aggregations

### DIFF
--- a/axiom/query/aggregation.go
+++ b/axiom/query/aggregation.go
@@ -8,7 +8,7 @@ import (
 
 //go:generate go run golang.org/x/tools/cmd/stringer -type=AggregationOp -linecomment -output=aggregation_string.go
 
-// An AggregationOp can be applied on queries to aggrgate based on different
+// An AggregationOp can be applied on queries to aggregate based on different
 // conditions.
 type AggregationOp uint8
 
@@ -17,8 +17,9 @@ const (
 	emptyAggregationOp AggregationOp = iota //
 
 	// Works with all types, field should be `*`.
-	OpCount         // count
-	OpCountDistinct // distinct
+	OpCount    // count
+	OpDistinct // distinct
+	OpMakeSet  // makeset
 
 	// Only works for numbers.
 	OpSum               // sum
@@ -28,13 +29,15 @@ const (
 	OpTopk              // topk
 	OpPercentiles       // percentiles
 	OpHistogram         // histogram
-	OpVariance          // variance
 	OpStandardDeviation // stdev
+	OpVariance          // variance
+	OpArgMin            // argmin
+	OpArgMax            // argmax
 
 	// Read-only. Not to be used for query requests. Only in place to support
 	// the APL query result.
-	OpCountIf         // countif
-	OpCountDistinctIf // distinctif
+	OpCountIf    // countif
+	OpDistinctIf // distinctif
 )
 
 func aggregationOpFromString(s string) (op AggregationOp, err error) {
@@ -43,8 +46,10 @@ func aggregationOpFromString(s string) (op AggregationOp, err error) {
 		op = emptyAggregationOp
 	case OpCount.String():
 		op = OpCount
-	case OpCountDistinct.String():
-		op = OpCountDistinct
+	case OpDistinct.String():
+		op = OpDistinct
+	case OpMakeSet.String():
+		op = OpMakeSet
 	case OpSum.String():
 		op = OpSum
 	case OpAvg.String():
@@ -59,14 +64,18 @@ func aggregationOpFromString(s string) (op AggregationOp, err error) {
 		op = OpPercentiles
 	case OpHistogram.String():
 		op = OpHistogram
-	case OpVariance.String():
-		op = OpVariance
 	case OpStandardDeviation.String():
 		op = OpStandardDeviation
+	case OpVariance.String():
+		op = OpVariance
+	case OpArgMin.String():
+		op = OpArgMin
+	case OpArgMax.String():
+		op = OpArgMax
 	case OpCountIf.String():
 		op = OpCountIf
-	case OpCountDistinctIf.String():
-		op = OpCountDistinctIf
+	case OpDistinctIf.String():
+		op = OpDistinctIf
 	default:
 		err = fmt.Errorf("unknown aggregation operation %q", s)
 	}
@@ -102,7 +111,7 @@ type Aggregation struct {
 	Op AggregationOp `json:"op"`
 	// Field the aggregation operation is performed on.
 	Field string `json:"field"`
-	// Argument to the aggregation. Only valid for `OpCountDistinctIf`,
+	// Argument to the aggregation. Only valid for `OpDistinctIf`,
 	// `OpTopk`, `OpPercentiles` and `OpHistogram`
 	// aggregations.
 	Argument interface{} `json:"argument"`

--- a/axiom/query/aggregation_string.go
+++ b/axiom/query/aggregation_string.go
@@ -10,23 +10,26 @@ func _() {
 	var x [1]struct{}
 	_ = x[emptyAggregationOp-0]
 	_ = x[OpCount-1]
-	_ = x[OpCountDistinct-2]
-	_ = x[OpSum-3]
-	_ = x[OpAvg-4]
-	_ = x[OpMin-5]
-	_ = x[OpMax-6]
-	_ = x[OpTopk-7]
-	_ = x[OpPercentiles-8]
-	_ = x[OpHistogram-9]
-	_ = x[OpVariance-10]
+	_ = x[OpDistinct-2]
+	_ = x[OpMakeSet-3]
+	_ = x[OpSum-4]
+	_ = x[OpAvg-5]
+	_ = x[OpMin-6]
+	_ = x[OpMax-7]
+	_ = x[OpTopk-8]
+	_ = x[OpPercentiles-9]
+	_ = x[OpHistogram-10]
 	_ = x[OpStandardDeviation-11]
-	_ = x[OpCountIf-12]
-	_ = x[OpCountDistinctIf-13]
+	_ = x[OpVariance-12]
+	_ = x[OpArgMin-13]
+	_ = x[OpArgMax-14]
+	_ = x[OpCountIf-15]
+	_ = x[OpDistinctIf-16]
 }
 
-const _AggregationOp_name = "countdistinctsumavgminmaxtopkpercentileshistogramvariancestdevcountifdistinctif"
+const _AggregationOp_name = "countdistinctmakesetsumavgminmaxtopkpercentileshistogramstdevvarianceargminargmaxcountifdistinctif"
 
-var _AggregationOp_index = [...]uint8{0, 0, 5, 13, 16, 19, 22, 25, 29, 40, 49, 57, 62, 69, 79}
+var _AggregationOp_index = [...]uint8{0, 0, 5, 13, 20, 23, 26, 29, 32, 36, 47, 56, 61, 69, 75, 81, 88, 98}
 
 func (i AggregationOp) String() string {
 	if i >= AggregationOp(len(_AggregationOp_index)-1) {

--- a/axiom/query/aggregation_test.go
+++ b/axiom/query/aggregation_test.go
@@ -40,9 +40,9 @@ func TestAggregationOp_String(t *testing.T) {
 	assert.Empty(t, AggregationOp(0).String())
 	assert.Empty(t, emptyAggregationOp.String())
 	assert.Equal(t, emptyAggregationOp, AggregationOp(0))
-	assert.Contains(t, (OpCountDistinctIf + 1).String(), "AggregationOp(")
+	assert.Contains(t, (OpDistinctIf + 1).String(), "AggregationOp(")
 
-	for op := OpCount; op <= OpCountDistinctIf; op++ {
+	for op := OpCount; op <= OpDistinctIf; op++ {
 		s := op.String()
 		assert.NotEmpty(t, s)
 		assert.NotContains(t, s, "AggregationOp(")
@@ -50,7 +50,7 @@ func TestAggregationOp_String(t *testing.T) {
 }
 
 func TestAggregationOpFromString(t *testing.T) {
-	for op := OpCount; op <= OpCountDistinctIf; op++ {
+	for op := OpCount; op <= OpDistinctIf; op++ {
 		s := op.String()
 
 		parsedOp, err := aggregationOpFromString(s)


### PR DESCRIPTION
This PR adds three new aggregations to `axiom-go`:

* `argmin`
* `argmax`
* `makeset`