### PR TITLE
fix(query): parse unknown aggregations gracefully

### DIFF
--- a/axiom/query/aggregation.go
+++ b/axiom/query/aggregation.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -14,7 +13,7 @@ type AggregationOp uint8
 
 // All available query aggregation operations.
 const (
-	emptyAggregationOp AggregationOp = iota //
+	OpUnknown AggregationOp = iota // unknown
 
 	// Works with all types, field should be `*`.
 	OpCount    // count
@@ -40,10 +39,8 @@ const (
 	OpDistinctIf // distinctif
 )
 
-func aggregationOpFromString(s string) (op AggregationOp, err error) {
+func aggregationOpFromString(s string) (op AggregationOp) {
 	switch strings.ToLower(s) {
-	case emptyAggregationOp.String():
-		op = emptyAggregationOp
 	case OpCount.String():
 		op = OpCount
 	case OpDistinct.String():
@@ -77,10 +74,10 @@ func aggregationOpFromString(s string) (op AggregationOp, err error) {
 	case OpDistinctIf.String():
 		op = OpDistinctIf
 	default:
-		err = fmt.Errorf("unknown aggregation operation %q", s)
+		op = OpUnknown
 	}
 
-	return op, err
+	return op
 }
 
 // MarshalJSON implements `json.Marshaler`. It is in place to marshal the
@@ -98,9 +95,9 @@ func (op *AggregationOp) UnmarshalJSON(b []byte) (err error) {
 		return err
 	}
 
-	*op, err = aggregationOpFromString(s)
+	*op = aggregationOpFromString(s)
 
-	return err
+	return nil
 }
 
 // Aggregation performed as part of a query.

--- a/axiom/query/aggregation_string.go
+++ b/axiom/query/aggregation_string.go
@@ -8,7 +8,7 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[emptyAggregationOp-0]
+	_ = x[OpUnknown-0]
 	_ = x[OpCount-1]
 	_ = x[OpDistinct-2]
 	_ = x[OpMakeSet-3]
@@ -27,9 +27,9 @@ func _() {
 	_ = x[OpDistinctIf-16]
 }
 
-const _AggregationOp_name = "countdistinctmakesetsumavgminmaxtopkpercentileshistogramstdevvarianceargminargmaxcountifdistinctif"
+const _AggregationOp_name = "unknowncountdistinctmakesetsumavgminmaxtopkpercentileshistogramstdevvarianceargminargmaxcountifdistinctif"
 
-var _AggregationOp_index = [...]uint8{0, 0, 5, 13, 20, 23, 26, 29, 32, 36, 47, 56, 61, 69, 75, 81, 88, 98}
+var _AggregationOp_index = [...]uint8{0, 7, 12, 20, 27, 30, 33, 36, 39, 43, 54, 63, 68, 76, 82, 88, 95, 105}
 
 func (i AggregationOp) String() string {
 	if i >= AggregationOp(len(_AggregationOp_index)-1) {

--- a/axiom/query/aggregation_test.go
+++ b/axiom/query/aggregation_test.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Fine to have a bit of duplication in a test file.
 package query
 
 import (
@@ -37,12 +36,10 @@ func TestAggregationOp_Unmarshal(t *testing.T) {
 
 func TestAggregationOp_String(t *testing.T) {
 	// Check outer bounds.
-	assert.Empty(t, AggregationOp(0).String())
-	assert.Empty(t, emptyAggregationOp.String())
-	assert.Equal(t, emptyAggregationOp, AggregationOp(0))
+	assert.Equal(t, OpUnknown, AggregationOp(0))
 	assert.Contains(t, (OpDistinctIf + 1).String(), "AggregationOp(")
 
-	for op := OpCount; op <= OpDistinctIf; op++ {
+	for op := OpUnknown; op <= OpDistinctIf; op++ {
 		s := op.String()
 		assert.NotEmpty(t, s)
 		assert.NotContains(t, s, "AggregationOp(")
@@ -50,12 +47,10 @@ func TestAggregationOp_String(t *testing.T) {
 }
 
 func TestAggregationOpFromString(t *testing.T) {
-	for op := OpCount; op <= OpDistinctIf; op++ {
+	for op := OpUnknown; op <= OpDistinctIf; op++ {
 		s := op.String()
 
-		parsedOp, err := aggregationOpFromString(s)
-		assert.NoError(t, err)
-
+		parsedOp := aggregationOpFromString(s)
 		assert.NotEmpty(t, s)
 		assert.Equal(t, op, parsedOp)
 	}

--- a/axiom/query/filter_test.go
+++ b/axiom/query/filter_test.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Fine to have a bit of duplication in a test file.
 package query
 
 import (


### PR DESCRIPTION
Fixes an issue when running an APL query with an aggregation that has not yet been defined in `axiom-go`.