### PR TITLE
chore: code grooming

### DIFF
--- a/adapters/apex/apex_test.go
+++ b/adapters/apex/apex_test.go
@@ -144,7 +144,7 @@ func setup(t *testing.T, h http.HandlerFunc) (*log.Logger, func()) {
 }
 
 // JSONEqExp is like assert.JSONEq() but excludes the given fields.
-func JSONEqExp(t assert.TestingT, expected string, actual string, excludedFields []string, msgAndArgs ...interface{}) bool {
+func JSONEqExp(t assert.TestingT, expected string, actual string, excludedFields []string, msgAndArgs ...any) bool {
 	type tHelper interface {
 		Helper()
 	}
@@ -153,7 +153,7 @@ func JSONEqExp(t assert.TestingT, expected string, actual string, excludedFields
 		h.Helper()
 	}
 
-	var expectedJSONAsInterface, actualJSONAsInterface map[string]interface{}
+	var expectedJSONAsInterface, actualJSONAsInterface map[string]any
 
 	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {
 		return assert.Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -206,7 +206,7 @@ func (c *Client) populateClientFromEnvironment() (err error) {
 
 // call creates a new API request and executes it. The response body is JSON
 // decoded or directly written to v, depending on v being an io.Writer or not.
-func (c *Client) call(ctx context.Context, method, path string, body, v interface{}) error {
+func (c *Client) call(ctx context.Context, method, path string, body, v any) error {
 	req, err := c.newRequest(ctx, method, path, body)
 	if err != nil {
 		return err
@@ -219,7 +219,7 @@ func (c *Client) call(ctx context.Context, method, path string, body, v interfac
 // newRequest creates an API request. If specified, the value pointed to by body
 // will be included as the request body. If it is not an io.Reader, it will be
 // included as a JSON encoded request body.
-func (c *Client) newRequest(ctx context.Context, method, path string, body interface{}) (*http.Request, error) {
+func (c *Client) newRequest(ctx context.Context, method, path string, body any) (*http.Request, error) {
 	rel, err := url.ParseRequestURI(path)
 	if err != nil {
 		return nil, err
@@ -278,7 +278,7 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body inter
 // not.
 // If the rate limit is exceeded and reset time is in the future, it returns
 // `*LimitError` immediately without making an API call.
-func (c *Client) do(req *http.Request, v interface{}) (*response, error) {
+func (c *Client) do(req *http.Request, v any) (*response, error) {
 	// If we've hit the rate limit, don't make further requests before
 	// the reset time.
 	if err := c.checkLimit(req); err != nil {

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -59,7 +59,7 @@ const (
 )
 
 // An Event is a map of key-value pairs.
-type Event map[string]interface{}
+type Event map[string]any
 
 // Dataset represents an Axiom dataset.
 type Dataset struct {
@@ -126,9 +126,9 @@ type wrappedDataset struct {
 
 	// HINT(lukasmalkmus) This is some future stuff we don't yet support in this
 	// package so we just ignore it for now.
-	IntegrationConfigs interface{} `json:"integrationConfigs,omitempty"`
-	IntegrationFilters interface{} `json:"integrationFilters,omitempty"`
-	QuickQueries       interface{} `json:"quickQueries,omitempty"`
+	IntegrationConfigs any `json:"integrationConfigs,omitempty"`
+	IntegrationFilters any `json:"integrationFilters,omitempty"`
+	QuickQueries       any `json:"quickQueries,omitempty"`
 }
 
 type datasetTrimRequest struct {
@@ -407,7 +407,7 @@ func (s *DatasetsService) Query(ctx context.Context, id string, q query.Query, o
 	var (
 		res struct {
 			query.Result
-			FieldsMeta interface{} `json:"fieldsMeta"`
+			FieldsMeta any `json:"fieldsMeta"`
 		}
 		resp *response
 	)
@@ -439,7 +439,7 @@ func (s *DatasetsService) APLQuery(ctx context.Context, q apl.Query, opts apl.Op
 	var (
 		res struct {
 			apl.Result
-			FieldsMeta interface{} `json:"fieldsMetaMap"`
+			FieldsMeta any `json:"fieldsMetaMap"`
 		}
 		resp *response
 	)

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -150,7 +150,7 @@ var expQueryRes = &query.Result{
 			Time:    parseTimeOrPanic("2020-11-19T11:06:31.569475746Z"),
 			SysTime: parseTimeOrPanic("2020-11-19T11:06:31.581384524Z"),
 			RowID:   "c776x1uafkpu-4918f6cb9000095-0",
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"agent":       "Debian APT-HTTP/1.3 (0.8.16~exp12ubuntu10.21)",
 				"bytes":       float64(0),
 				"referrer":    "-",
@@ -165,7 +165,7 @@ var expQueryRes = &query.Result{
 			Time:    parseTimeOrPanic("2020-11-19T11:06:31.569479846Z"),
 			SysTime: parseTimeOrPanic("2020-11-19T11:06:31.581384524Z"),
 			RowID:   "c776x1uafnvq-4918f6cb9000095-1",
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"agent":       "Debian APT-HTTP/1.3 (0.8.16~exp12ubuntu10.21)",
 				"bytes":       float64(0),
 				"referrer":    "-",
@@ -712,7 +712,7 @@ func TestDetectContentType(t *testing.T) {
 
 func assertValidJSON(t *testing.T, r io.Reader) {
 	dec := json.NewDecoder(r)
-	var v interface{}
+	var v any
 	for dec.More() {
 		err := dec.Decode(&v)
 		assert.NoError(t, err)

--- a/axiom/options.go
+++ b/axiom/options.go
@@ -10,7 +10,7 @@ import (
 // addOptions adds the parameters in opt as URL query parameters to s. opt must
 // be a struct whose fields may contain "url" tags.
 // https://github.com/google/go-github/blob/master/github/github.go#L232
-func addOptions(s string, opt interface{}) (string, error) {
+func addOptions(s string, opt any) (string, error) {
 	v := reflect.ValueOf(opt)
 	if v.Kind() == reflect.Ptr && v.IsNil() {
 		return s, nil

--- a/axiom/orgs.go
+++ b/axiom/orgs.go
@@ -166,7 +166,7 @@ type wrappedOrganization struct {
 
 	// HINT(lukasmalkmus) This is some future stuff we don't yet support in this
 	// package so we just ignore it for now.
-	ExternalPlan interface{} `json:"externalPlan,omitempty"`
+	ExternalPlan any `json:"externalPlan,omitempty"`
 }
 
 // OrganizationsService handles communication with the organization related

--- a/axiom/query/aggregation.go
+++ b/axiom/query/aggregation.go
@@ -16,10 +16,9 @@ const (
 	OpUnknown AggregationOp = iota // unknown
 
 	// Works with all types, field should be `*`.
-	OpCount     // count
-	OpDistinct  // distinct
-	OpMakeSet   // makeset
-	OpMakeSetIf // makesetif
+	OpCount    // count
+	OpDistinct // distinct
+	OpMakeSet  // makeset
 
 	// Only works for numbers.
 	OpSum               // sum
@@ -38,6 +37,7 @@ const (
 	// the APL query result.
 	OpCountIf    // countif
 	OpDistinctIf // distinctif
+	OpMakeSetIf  // makesetif
 )
 
 func aggregationOpFromString(s string) (op AggregationOp) {
@@ -48,8 +48,6 @@ func aggregationOpFromString(s string) (op AggregationOp) {
 		op = OpDistinct
 	case OpMakeSet.String():
 		op = OpMakeSet
-	case OpMakeSetIf.String():
-		op = OpMakeSetIf
 	case OpSum.String():
 		op = OpSum
 	case OpAvg.String():
@@ -76,6 +74,8 @@ func aggregationOpFromString(s string) (op AggregationOp) {
 		op = OpCountIf
 	case OpDistinctIf.String():
 		op = OpDistinctIf
+	case OpMakeSetIf.String():
+		op = OpMakeSetIf
 	default:
 		op = OpUnknown
 	}
@@ -114,5 +114,5 @@ type Aggregation struct {
 	// Argument to the aggregation. Only valid for `OpDistinctIf`,
 	// `OpTopk`, `OpPercentiles` and `OpHistogram`
 	// aggregations.
-	Argument interface{} `json:"argument"`
+	Argument any `json:"argument"`
 }

--- a/axiom/query/aggregation_string.go
+++ b/axiom/query/aggregation_string.go
@@ -12,25 +12,25 @@ func _() {
 	_ = x[OpCount-1]
 	_ = x[OpDistinct-2]
 	_ = x[OpMakeSet-3]
-	_ = x[OpMakeSetIf-4]
-	_ = x[OpSum-5]
-	_ = x[OpAvg-6]
-	_ = x[OpMin-7]
-	_ = x[OpMax-8]
-	_ = x[OpTopk-9]
-	_ = x[OpPercentiles-10]
-	_ = x[OpHistogram-11]
-	_ = x[OpStandardDeviation-12]
-	_ = x[OpVariance-13]
-	_ = x[OpArgMin-14]
-	_ = x[OpArgMax-15]
-	_ = x[OpCountIf-16]
-	_ = x[OpDistinctIf-17]
+	_ = x[OpSum-4]
+	_ = x[OpAvg-5]
+	_ = x[OpMin-6]
+	_ = x[OpMax-7]
+	_ = x[OpTopk-8]
+	_ = x[OpPercentiles-9]
+	_ = x[OpHistogram-10]
+	_ = x[OpStandardDeviation-11]
+	_ = x[OpVariance-12]
+	_ = x[OpArgMin-13]
+	_ = x[OpArgMax-14]
+	_ = x[OpCountIf-15]
+	_ = x[OpDistinctIf-16]
+	_ = x[OpMakeSetIf-17]
 }
 
-const _AggregationOp_name = "unknowncountdistinctmakesetmakesetifsumavgminmaxtopkpercentileshistogramstdevvarianceargminargmaxcountifdistinctif"
+const _AggregationOp_name = "unknowncountdistinctmakesetsumavgminmaxtopkpercentileshistogramstdevvarianceargminargmaxcountifdistinctifmakesetif"
 
-var _AggregationOp_index = [...]uint8{0, 7, 12, 20, 27, 36, 39, 42, 45, 48, 52, 63, 72, 77, 85, 91, 97, 104, 114}
+var _AggregationOp_index = [...]uint8{0, 7, 12, 20, 27, 30, 33, 36, 39, 43, 54, 63, 68, 76, 82, 88, 95, 105, 114}
 
 func (i AggregationOp) String() string {
 	if i >= AggregationOp(len(_AggregationOp_index)-1) {

--- a/axiom/query/aggregation_test.go
+++ b/axiom/query/aggregation_test.go
@@ -37,9 +37,9 @@ func TestAggregationOp_Unmarshal(t *testing.T) {
 func TestAggregationOp_String(t *testing.T) {
 	// Check outer bounds.
 	assert.Equal(t, OpUnknown, AggregationOp(0))
-	assert.Contains(t, (OpDistinctIf + 1).String(), "AggregationOp(")
+	assert.Contains(t, (OpMakeSetIf + 1).String(), "AggregationOp(")
 
-	for op := OpUnknown; op <= OpDistinctIf; op++ {
+	for op := OpUnknown; op <= OpMakeSetIf; op++ {
 		s := op.String()
 		assert.NotEmpty(t, s)
 		assert.NotContains(t, s, "AggregationOp(")
@@ -47,7 +47,7 @@ func TestAggregationOp_String(t *testing.T) {
 }
 
 func TestAggregationOpFromString(t *testing.T) {
-	for op := OpUnknown; op <= OpDistinctIf; op++ {
+	for op := OpUnknown; op <= OpMakeSetIf; op++ {
 		s := op.String()
 
 		parsedOp := aggregationOpFromString(s)

--- a/axiom/query/filter.go
+++ b/axiom/query/filter.go
@@ -119,7 +119,7 @@ type Filter struct {
 	// Field the filter operation is performed on.
 	Field string `json:"field"`
 	// Value to perform the filter operation against.
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 	// CaseSensitive specifies if the filter is case sensitive or not. Only
 	// valid for OpStartsWith, OpNotStartsWith, OpEndsWith, OpNotEndsWith,
 	// OpContains and OpNotContains.

--- a/axiom/query/result.go
+++ b/axiom/query/result.go
@@ -222,7 +222,7 @@ type Entry struct {
 	RowID string `json:"_rowId"`
 	// Data contains the raw data of the event (with filters and aggregations
 	// applied).
-	Data map[string]interface{} `json:"data"`
+	Data map[string]any `json:"data"`
 }
 
 // Timeseries are queried time series.
@@ -248,7 +248,7 @@ type EntryGroup struct {
 	// ID is the unique the group.
 	ID uint64 `json:"id"`
 	// Group maps the fieldnames to the unique values for the entry.
-	Group map[string]interface{} `json:"group"`
+	Group map[string]any `json:"group"`
 	// Aggregations of the group.
 	Aggregations []EntryGroupAgg `json:"aggregations"`
 }
@@ -259,5 +259,5 @@ type EntryGroupAgg struct {
 	// is the uppercased string representation of the aggregation operation.
 	Alias string `json:"op"`
 	// Value is the result value of the aggregation.
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }

--- a/axiom/sas/filter.go
+++ b/axiom/sas/filter.go
@@ -7,7 +7,7 @@ import "github.com/axiomhq/axiom-go/axiom/query"
 type filter struct {
 	Op            query.FilterOp `json:"op"`
 	Field         string         `json:"fd"`
-	Value         interface{}    `json:"vl"`
+	Value         any            `json:"vl"`
 	CaseSensitive bool           `json:"cs"`
 	Children      []filter       `json:"ch,omitempty"`
 }


### PR DESCRIPTION
This PR introduces `any` over `interface` and changes the order of one aggregation operation into the correct comment group.