### PR TITLE
IngestChannel batching

### DIFF
--- a/adapters/apex/apex.go
+++ b/adapters/apex/apex.go
@@ -3,7 +3,7 @@ package apex
 import (
 	"context"
 	"errors"
-	"fmt"
+	stdlog "log"
 	"os"
 	"sync"
 	"time"
@@ -120,12 +120,14 @@ func New(options ...Option) (*Handler, error) {
 	go func() {
 		defer close(handler.closeCh)
 
+		logger := stdlog.New(os.Stderr, "[AXIOM|APEX]", 0)
+
 		res, err := handler.client.Datasets.IngestChannel(context.Background(), handler.datasetName, handler.eventCh, handler.ingestOptions...)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to ingest events: %s\n", err)
+			logger.Printf("failed to ingest events: %s\n", err)
 		} else if res.Failed > 0 {
 			// Best effort on notifying the user about the ingest failure.
-			fmt.Fprintf(os.Stderr, "event at %s failed to ingest: %s\n",
+			logger.Printf("event at %s failed to ingest: %s\n",
 				res.Failures[0].Timestamp, res.Failures[0].Error)
 		}
 	}()

--- a/adapters/apex/apex_test.go
+++ b/adapters/apex/apex_test.go
@@ -95,7 +95,7 @@ func TestHandler_FlushFullBatch(t *testing.T) {
 
 	logger := adapters.Setup(t, hf, setup(t))
 
-	for i := 0; i <= 1024; i++ {
+	for i := 0; i <= 1000; i++ {
 		logger.Info("my message")
 	}
 
@@ -103,13 +103,13 @@ func TestHandler_FlushFullBatch(t *testing.T) {
 	time.Sleep(250 * time.Millisecond)
 
 	// Should have a full batch right away.
-	assert.EqualValues(t, 1024, atomic.LoadUint64(&lines))
+	assert.EqualValues(t, 1000, atomic.LoadUint64(&lines))
 
 	// Wait for timer based handler flush.
 	time.Sleep(1250 * time.Millisecond)
 
 	// Should have received the last event.
-	assert.EqualValues(t, 1025, atomic.LoadUint64(&lines))
+	assert.EqualValues(t, 1001, atomic.LoadUint64(&lines))
 }
 
 func setup(t *testing.T) func(dataset string, client *axiom.Client) *log.Logger {

--- a/adapters/logrus/logrus.go
+++ b/adapters/logrus/logrus.go
@@ -3,7 +3,7 @@ package logrus
 import (
 	"context"
 	"errors"
-	"fmt"
+	stdlog "log"
 	"os"
 	"sync"
 	"time"
@@ -132,12 +132,14 @@ func New(options ...Option) (*Hook, error) {
 	go func() {
 		defer close(hook.closeCh)
 
+		logger := stdlog.New(os.Stderr, "[AXIOM|LOGRUS]", 0)
+
 		res, err := hook.client.Datasets.IngestChannel(context.Background(), hook.datasetName, hook.eventCh, hook.ingestOptions...)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to ingest events: %s\n", err)
+			logger.Printf("failed to ingest events: %s\n", err)
 		} else if res.Failed > 0 {
 			// Best effort on notifying the user about the ingest failure.
-			fmt.Fprintf(os.Stderr, "event at %s failed to ingest: %s\n",
+			logger.Printf("event at %s failed to ingest: %s\n",
 				res.Failures[0].Timestamp, res.Failures[0].Error)
 		}
 	}()

--- a/adapters/logrus/logrus_test.go
+++ b/adapters/logrus/logrus_test.go
@@ -94,7 +94,7 @@ func TestHook_FlushFullBatch(t *testing.T) {
 
 	logger := adapters.Setup(t, hf, setup(t))
 
-	for i := 0; i <= 1024; i++ {
+	for i := 0; i <= 1000; i++ {
 		logger.Info("my message")
 	}
 
@@ -102,13 +102,13 @@ func TestHook_FlushFullBatch(t *testing.T) {
 	time.Sleep(250 * time.Millisecond)
 
 	// Should have a full batch right away.
-	assert.EqualValues(t, 1024, atomic.LoadUint64(&lines))
+	assert.EqualValues(t, 1000, atomic.LoadUint64(&lines))
 
 	// Wait for timer based hook flush.
 	time.Sleep(1250 * time.Millisecond)
 
 	// Should have received the last event.
-	assert.EqualValues(t, 1025, atomic.LoadUint64(&lines))
+	assert.EqualValues(t, 1001, atomic.LoadUint64(&lines))
 }
 
 func setup(t *testing.T) func(dataset string, client *axiom.Client) *logrus.Logger {

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -385,9 +385,9 @@ func (s *DatasetsService) IngestEvents(ctx context.Context, id string, events []
 // Restrictions for field names (JSON object keys) can be reviewed here:
 // https://www.axiom.co/docs/usage/field-restrictions.
 //
-// Events are ingested in batches. A batch is either 1024 events for unbuffered
+// Events are ingested in batches. A batch is either 1000 events for unbuffered
 // channels or the capacity of the channel for buffered channels. The maximum
-// batch size is 1024*10. A batch is sent to the server as soon as it is full,
+// batch size is 1000. A batch is sent to the server as soon as it is full,
 // after one second or when the channel is closed.
 //
 // The method returns with an error when the context is marked as done or an
@@ -404,12 +404,10 @@ func (s *DatasetsService) IngestChannel(ctx context.Context, id string, events <
 	))
 	defer span.End()
 
-	// Batch is either 1024 events for unbuffered channels or the capacity of
-	// the channel for buffered channels. The maximum batch size is 1024*10.
-	batchSize := 1024
-	if cap(events) > batchSize*10 {
-		batchSize *= 10
-	} else if cap(events) > 0 {
+	// Batch is either 1000 events for unbuffered channels or the capacity of
+	// the channel for buffered channels. The maximum batch size is 1000.
+	batchSize := 1000
+	if cap(events) > 0 && cap(events) <= batchSize {
 		batchSize = cap(events)
 	}
 	batch := make([]Event, 0, batchSize)

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -660,14 +660,14 @@ func TestDatasetsService_IngestChannel_Buffered(t *testing.T) {
 		// For the sake of simplicity in this handler, we'll just return the
 		// same WAL length for each request.
 		w.Header().Set("Content-Type", mediaTypeJSON)
-		_, err = fmt.Fprint(w, `{
-			"ingested": 1,
+		_, err = fmt.Fprintf(w, `{
+			"ingested": %d,
 			"failed": 0,
 			"failures": [],
-			"processedBytes": 630,
+			"processedBytes": %d,
 			"blocksCreated": 0,
 			"walLength": 2
-		}`)
+		}`, len(events), len(events)*630)
 		assert.NoError(t, err)
 	}
 
@@ -732,15 +732,17 @@ func TestDatasetsService_IngestChannel_UnbufferedSlow(t *testing.T) {
 		assert.Len(t, events, 1)
 		zsr.Close()
 
+		// For the sake of simplicity in this handler, we'll just return the
+		// same WAL length for each request.
 		w.Header().Set("Content-Type", mediaTypeJSON)
-		_, err = fmt.Fprint(w, `{
-			"ingested": 1,
+		_, err = fmt.Fprintf(w, `{
+			"ingested": %d,
 			"failed": 0,
 			"failures": [],
-			"processedBytes": 630,
+			"processedBytes": %d,
 			"blocksCreated": 0,
 			"walLength": 2
-		}`)
+		}`, len(events), len(events)*630)
 		assert.NoError(t, err)
 	}
 
@@ -773,6 +775,8 @@ func TestDatasetsService_IngestChannel_UnbufferedSlow(t *testing.T) {
 	go func() {
 		for _, e := range events {
 			eventCh <- e
+			// Simulate a slow producer which should trigger the ticker based
+			// batch flush in the IngestChannel method.
 			time.Sleep(time.Second + 250*time.Millisecond)
 		}
 		close(eventCh)
@@ -811,14 +815,14 @@ func TestDatasetsService_IngestChannel_BufferedSlow(t *testing.T) {
 		// For the sake of simplicity in this handler, we'll just return the
 		// same WAL length for each request.
 		w.Header().Set("Content-Type", mediaTypeJSON)
-		_, err = fmt.Fprint(w, `{
-			"ingested": 1,
+		_, err = fmt.Fprintf(w, `{
+			"ingested": %d,
 			"failed": 0,
 			"failures": [],
-			"processedBytes": 630,
+			"processedBytes": %d,
 			"blocksCreated": 0,
 			"walLength": 2
-		}`)
+		}`, len(events), len(events)*630)
 		assert.NoError(t, err)
 	}
 
@@ -851,6 +855,8 @@ func TestDatasetsService_IngestChannel_BufferedSlow(t *testing.T) {
 	go func() {
 		for _, e := range events {
 			eventCh <- e
+			// Simulate a slow producer which should trigger the ticker based
+			// batch flush in the IngestChannel method.
 			time.Sleep(time.Second + 250*time.Millisecond)
 		}
 		close(eventCh)

--- a/axiom/ingest/status.go
+++ b/axiom/ingest/status.go
@@ -18,6 +18,16 @@ type Status struct {
 	WALLength uint32 `json:"walLength"`
 }
 
+// Add adds the status of another ingestion operation to the current status.
+func (s *Status) Add(other *Status) {
+	s.Ingested += other.Ingested
+	s.Failed += other.Failed
+	s.Failures = append(s.Failures, other.Failures...)
+	s.ProcessedBytes += other.ProcessedBytes
+	s.BlocksCreated += other.BlocksCreated
+	s.WALLength = other.WALLength
+}
+
 // Failure describes the ingestion failure of a single event.
 type Failure struct {
 	// Timestamp of the event that failed to ingest.

--- a/examples/ingesthackernews/main.go
+++ b/examples/ingesthackernews/main.go
@@ -136,7 +136,7 @@ func generateIDs(max uint64) <-chan uint64 {
 
 func fetchEvents(eventIDs <-chan uint64) <-chan axiom.Event {
 	var (
-		eventCh        = make(chan axiom.Event, maxWorkers*10)
+		eventCh        = make(chan axiom.Event, 1024)
 		workerErrGroup errgroup.Group
 	)
 


### PR DESCRIPTION
This PR adds batching support for the `IngestChannel` method. This reduces the possibility for opening connections that are open for a very long time and allows for batches to be automatically retried in case of http error.

The batching mechansim is relatively naive but should be good enough.