### PR TITLE
Improve documentation

### DIFF
--- a/.github/workflows/test_examples.yaml
+++ b/.github/workflows/test_examples.yaml
@@ -41,7 +41,7 @@ jobs:
               axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . == 2 )'
           - example: ingestfile
             setup: |
-              echo '[{"mood":"hyped","msg":"This is awesome!"}]' >> logs.json
+              echo '[{"timestamp":"1668773301","mood":"hyped","msg":"This is awesome!"}]' >> logs.json
             verify: |
               axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . == 1 )'
           - example: logrus

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Install using `go get`:
 go get github.com/axiomhq/axiom-go/axiom
 ```
 
+Import the package:
+
+```go
+import "github.com/axiomhq/axiom-go/axiom"
+```
+
 If you use the [Axiom CLI](https://github.com/axiomhq/cli), run
 `eval $(axiom config export -f)` to configure your environment variables.
 
@@ -49,7 +55,7 @@ the `axiom.NewClient` function:
 
 ```go
 client, err := axiom.NewClient(
-  SetPersonalTokenConfig("AXIOM_TOKEN", "AXIOM_ORG_ID"),
+    SetPersonalTokenConfig("AXIOM_TOKEN", "AXIOM_ORG_ID"),
 )
 ```
 
@@ -57,36 +63,36 @@ Create and use a client like this:
 
 ```go
 import (
-	"context"
-	"fmt"
-	"log"
+    "context"
+    "fmt"
+    "log"
 
-	"github.com/axiomhq/axiom-go/axiom"
+    "github.com/axiomhq/axiom-go/axiom"
+    "github.com/axiomhq/axiom-go/axiom/ingest"
 )
 
 func main() {
-	ctx := context.Background()
+    ctx := context.Background()
 
-	client, err := axiom.NewClient()
-	if err != nil {
-		log.Fatalln(err)
-	}
+    client, err := axiom.NewClient()
+    if err != nil {
+        log.Fatalln(err)
+    }
+    
+    if _, err = client.Datasets.IngestEvents(ctx, "my-dataset", []axiom.Event{
+        {ingest.TimestampField: time.Now(), "foo": "bar"},
+        {ingest.TimestampField: time.Now(), "bar": "foo"},
+    }); err != nil {
+        log.Fatalln(err)
+    }
 
-	_, err = client.Datasets.IngestEvents(ctx, "my-dataset", []axiom.Event{
-		{"foo": "bar"},
-		{"bar": "foo"},
-	})
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	res, err := client.Datasets.Query(ctx, "['my-dataset'] | where foo == 'bar' | limit 100")
-	if err != nil {
-		log.Fatalln(err)
-	}
-	for _, match := range res.Matches {
-		fmt.Println(match.Data)
-	}
+    res, err := client.Datasets.Query(ctx, "['my-dataset'] | where foo == 'bar' | limit 100")
+    if err != nil {
+        log.Fatalln(err)
+    }
+    for _, match := range res.Matches {
+        fmt.Println(match.Data)
+    }
 }
 ```
 

--- a/axiom/auth/doc.go
+++ b/axiom/auth/doc.go
@@ -1,3 +1,3 @@
 // Package auth implements the authentication flow to login to Axiom by visiting
-// a URL. A Personal Access Token is retrieved in exchange.
+// a URL. A personal token is retrieved in exchange.
 package auth

--- a/axiom/axiom_test.go
+++ b/axiom/axiom_test.go
@@ -24,14 +24,14 @@ func TestValidateEnvironment(t *testing.T) {
 	}{
 		{
 			name: "no environment",
-			err:  config.ErrMissingAccessToken,
+			err:  config.ErrMissingToken,
 		},
 		{
 			name: "bad environment",
 			environment: map[string]string{
 				"AXIOM_ORG_ID": "mycompany-1234",
 			},
-			err: config.ErrMissingAccessToken,
+			err: config.ErrMissingToken,
 		},
 		{
 			name: "good environment",

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -148,7 +148,7 @@ func (c *Client) Options(options ...Option) error {
 // ValidateCredentials makes sure the client can properly authenticate against
 // the configured Axiom deployment.
 func (c *Client) ValidateCredentials(ctx context.Context) error {
-	if config.IsPersonalToken(c.config.AccessToken()) {
+	if config.IsPersonalToken(c.config.Token()) {
 		_, err := c.Users.Current(ctx)
 		return err
 	}
@@ -181,7 +181,7 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body any) 
 	}
 	endpoint := c.config.BaseURL().ResolveReference(rel)
 
-	if config.IsAPIToken(c.config.AccessToken()) && !validOnlyAPITokenPaths.MatchString(endpoint.Path) {
+	if config.IsAPIToken(c.config.Token()) && !validOnlyAPITokenPaths.MatchString(endpoint.Path) {
 		return nil, ErrUnprivilegedToken
 	}
 
@@ -213,12 +213,12 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body any) 
 	}
 
 	// Set authorization header, if present.
-	if c.config.AccessToken() != "" {
-		req.Header.Set(headerAuthorization, "Bearer "+c.config.AccessToken())
+	if c.config.Token() != "" {
+		req.Header.Set(headerAuthorization, "Bearer "+c.config.Token())
 	}
 
 	// Set organization ID header when using a personal token.
-	if config.IsPersonalToken(c.config.AccessToken()) && c.config.OrganizationID() != "" {
+	if config.IsPersonalToken(c.config.Token()) && c.config.OrganizationID() != "" {
 		req.Header.Set(headerOrganizationID, c.config.OrganizationID())
 	}
 

--- a/axiom/client_export_test.go
+++ b/axiom/client_export_test.go
@@ -21,7 +21,7 @@ func TestClient_Manual(t *testing.T) {
 
 	client, err := axiom.NewClient(
 		axiom.SetURL(srv.URL),
-		axiom.SetAccessToken("xapt-123"),
+		axiom.SetToken("xapt-123"),
 		axiom.SetOrganizationID("123"),
 		axiom.SetClient(srv.Client()),
 		axiom.SetStrictDecoding(true),
@@ -57,7 +57,7 @@ func TestClient_Call(t *testing.T) {
 
 	client, err := axiom.NewClient(
 		axiom.SetURL(srv.URL),
-		axiom.SetAccessToken("xapt-123"),
+		axiom.SetToken("xapt-123"),
 		axiom.SetOrganizationID("123"),
 		axiom.SetClient(srv.Client()),
 		axiom.SetStrictDecoding(true),

--- a/axiom/client_integration_test.go
+++ b/axiom/client_integration_test.go
@@ -102,7 +102,7 @@ func newClient(additionalOptions ...axiom.Option) (*axiom.Client, error) {
 		options = append(options, axiom.SetURL(deploymentURL))
 	}
 	if accessToken != "" {
-		options = append(options, axiom.SetAccessToken(accessToken))
+		options = append(options, axiom.SetToken(accessToken))
 	}
 	if orgID != "" {
 		options = append(options, axiom.SetOrganizationID(orgID))

--- a/axiom/client_options.go
+++ b/axiom/client_options.go
@@ -12,23 +12,24 @@ import (
 // performing an operation.
 type Option func(c *Client) error
 
-// SetURL sets the base URL used by the client.
+// SetURL specifies the base URL used by the client.
 //
 // Can also be specified using the `AXIOM_URL` environment variable.
 func SetURL(baseURL string) Option {
 	return func(c *Client) error { return c.config.Options(config.SetURL(baseURL)) }
 }
 
-// SetAccessToken specifies the access token to use.
+// SetToken specifies the token used by the client.
 //
 // Can also be specified using the `AXIOM_TOKEN` environment variable.
-func SetAccessToken(accessToken string) Option {
-	return func(c *Client) error { return c.config.Options(config.SetAccessToken(accessToken)) }
+func SetToken(accessToken string) Option {
+	return func(c *Client) error { return c.config.Options(config.SetToken(accessToken)) }
 }
 
-// SetOrganizationID specifies the organization ID to use when connecting to
-// Axiom. When a personal token is used, this method can be used to switch
-// between organizations without creating a new client instance.
+// SetOrganizationID specifies the organization ID used by the client.
+//
+// When a personal token is used, this method can be used to switch between
+// organizations by passing it to the client's `Options` method.
 //
 // Can also be specified using the `AXIOM_ORG_ID` environment variable.
 func SetOrganizationID(organizationID string) Option {
@@ -37,10 +38,10 @@ func SetOrganizationID(organizationID string) Option {
 
 // SetPersonalTokenConfig specifies all properties needed in order to
 // successfully connect to Axiom with a personal token.
-func SetPersonalTokenConfig(personalAccessToken, organizationID string) Option {
+func SetPersonalTokenConfig(personalToken, organizationID string) Option {
 	return func(c *Client) error {
 		return c.Options(
-			SetAccessToken(personalAccessToken),
+			SetToken(personalToken),
 			SetOrganizationID(organizationID),
 		)
 	}
@@ -49,22 +50,22 @@ func SetPersonalTokenConfig(personalAccessToken, organizationID string) Option {
 // SetAPITokenConfig specifies all properties needed in order to successfully
 // connect to Axiom with an API token.
 func SetAPITokenConfig(apiToken string) Option {
-	return SetAccessToken(apiToken)
+	return SetToken(apiToken)
 }
 
-// SetClient specifies a custom http client that should be used to make
+// SetClient specifies the custom http client used by the client to make
 // requests.
-func SetClient(client *http.Client) Option {
+func SetClient(httpClient *http.Client) Option {
 	return func(c *Client) error {
-		if client == nil {
+		if httpClient == nil {
 			return nil
 		}
-		c.httpClient = client
+		c.httpClient = httpClient
 		return nil
 	}
 }
 
-// SetUserAgent sets the user agent used by the client.
+// SetUserAgent specifies the user agent used by the client.
 func SetUserAgent(userAgent string) Option {
 	return func(c *Client) error {
 		c.userAgent = userAgent
@@ -73,7 +74,7 @@ func SetUserAgent(userAgent string) Option {
 }
 
 // SetNoEnv prevents the client from deriving its configuration from the
-// environment.
+// environment (by auto reading "AXIOM_*" environment variables).
 func SetNoEnv() Option {
 	return func(c *Client) error {
 		c.noEnv = true

--- a/axiom/client_test.go
+++ b/axiom/client_test.go
@@ -51,19 +51,19 @@ func TestNewClient(t *testing.T) {
 	}{
 		{
 			name: "no environment no options",
-			err:  config.ErrMissingAccessToken,
+			err:  config.ErrMissingToken,
 		},
 		{
-			name: "no environment accessToken option",
+			name: "no environment token option",
 			options: []Option{
-				SetAccessToken(personalToken),
+				SetToken(personalToken),
 			},
 			err: config.ErrMissingOrganizationID,
 		},
 		{
-			name: "no environment accessToken option with API token",
+			name: "no environment token option with API token",
 			options: []Option{
-				SetAccessToken(apiToken),
+				SetToken(apiToken),
 			},
 		},
 		{
@@ -80,21 +80,21 @@ func TestNewClient(t *testing.T) {
 			},
 		},
 		{
-			name: "no environment accessToken and organizationID option",
+			name: "no environment token and organizationID option",
 			options: []Option{
-				SetAccessToken(personalToken),
+				SetToken(personalToken),
 				SetOrganizationID(organizationID),
 			},
 		},
 		{
-			name: "accessToken and organizationID environment no options",
+			name: "token and organizationID environment no options",
 			environment: map[string]string{
 				"AXIOM_TOKEN":  personalToken,
 				"AXIOM_ORG_ID": organizationID,
 			},
 		},
 		{
-			name: "accessToken environment organizationID option",
+			name: "token environment organizationID option",
 			environment: map[string]string{
 				"AXIOM_TOKEN": personalToken,
 			},
@@ -103,30 +103,30 @@ func TestNewClient(t *testing.T) {
 			},
 		},
 		{
-			name: "organizationID environment accessToken option",
+			name: "organizationID environment token option",
 			environment: map[string]string{
 				"AXIOM_ORG_ID": organizationID,
 			},
 			options: []Option{
-				SetAccessToken(personalToken),
+				SetToken(personalToken),
 			},
 		},
 		{
-			name: "no environment url and accessToken option",
+			name: "no environment url and token option",
 			options: []Option{
 				SetURL(endpoint),
-				SetAccessToken(personalToken),
+				SetToken(personalToken),
 			},
 		},
 		{
-			name: "url and accessToken environment no options",
+			name: "url and token environment no options",
 			environment: map[string]string{
 				"AXIOM_URL":   endpoint,
 				"AXIOM_TOKEN": personalToken,
 			},
 		},
 		{
-			name: "accessToken and organizationID environment cloudUrl option",
+			name: "token and organizationID environment cloudUrl option",
 			environment: map[string]string{
 				"AXIOM_TOKEN":  personalToken,
 				"AXIOM_ORG_ID": organizationID,
@@ -136,7 +136,7 @@ func TestNewClient(t *testing.T) {
 			},
 		},
 		{
-			name: "accessToken and organizationID environment enhanced cloudUrl option",
+			name: "token and organizationID environment enhanced cloudUrl option",
 			environment: map[string]string{
 				"AXIOM_TOKEN":  personalToken,
 				"AXIOM_ORG_ID": organizationID,
@@ -146,7 +146,7 @@ func TestNewClient(t *testing.T) {
 			},
 		},
 		{
-			name: "cloudUrl accessToken and organizationID environment no options",
+			name: "cloudUrl token and organizationID environment no options",
 			environment: map[string]string{
 				"AXIOM_URL":    config.CloudURL().String(),
 				"AXIOM_TOKEN":  personalToken,
@@ -154,7 +154,7 @@ func TestNewClient(t *testing.T) {
 			},
 		},
 		{
-			name: "enhanced cloudUrl, accessToken and organizationID environment no options",
+			name: "enhanced cloudUrl, token and organizationID environment no options",
 			environment: map[string]string{
 				"AXIOM_URL":    config.CloudURL().String() + "/",
 				"AXIOM_TOKEN":  personalToken,
@@ -162,7 +162,7 @@ func TestNewClient(t *testing.T) {
 			},
 		},
 		{
-			name: "dev url, accessToken and organizationID environment no options",
+			name: "dev url, token and organizationID environment no options",
 			environment: map[string]string{
 				"AXIOM_URL":    "https://dev.axiom.co",
 				"AXIOM_TOKEN":  personalToken,
@@ -170,7 +170,7 @@ func TestNewClient(t *testing.T) {
 			},
 		},
 		{
-			name: "cloudUrl and accessToken environment organizationID option",
+			name: "cloudUrl and token environment organizationID option",
 			environment: map[string]string{
 				"AXIOM_URL":   config.CloudURL().String(),
 				"AXIOM_TOKEN": personalToken,
@@ -180,7 +180,7 @@ func TestNewClient(t *testing.T) {
 			},
 		},
 		{
-			name: "accessToken and organizationID environment noEnv option",
+			name: "token and organizationID environment noEnv option",
 			environment: map[string]string{
 				"AXIOM_TOKEN":  personalToken,
 				"AXIOM_ORG_ID": organizationID,
@@ -188,14 +188,14 @@ func TestNewClient(t *testing.T) {
 			options: []Option{
 				SetNoEnv(),
 			},
-			err: config.ErrMissingAccessToken,
+			err: config.ErrMissingToken,
 		},
 		{
-			name: "no environment noEnv, cloudUrl and accessToken option with API token",
+			name: "no environment noEnv, cloudUrl and token option with API token",
 			options: []Option{
 				SetNoEnv(),
 				SetURL(config.CloudURL().String()),
-				SetAccessToken(apiToken),
+				SetToken(apiToken),
 			},
 		},
 	}
@@ -211,7 +211,7 @@ func TestNewClient(t *testing.T) {
 			if tt.err != nil {
 				assert.ErrorIs(t, err, tt.err)
 			} else if assert.NoError(t, err) {
-				assert.Regexp(t, tokenRe, client.config.AccessToken())
+				assert.Regexp(t, tokenRe, client.config.Token())
 				assert.NotEmpty(t, client.config.BaseURL())
 			}
 		})
@@ -228,7 +228,7 @@ func TestNewClient_Valid(t *testing.T) {
 
 	// Is default configuration present?
 	assert.Equal(t, endpoint, client.config.BaseURL().String())
-	assert.Equal(t, personalToken, client.config.AccessToken())
+	assert.Equal(t, personalToken, client.config.Token())
 	assert.Empty(t, client.config.OrganizationID())
 	assert.NotNil(t, client.httpClient)
 	assert.NotEmpty(t, client.userAgent)
@@ -237,16 +237,16 @@ func TestNewClient_Valid(t *testing.T) {
 	assert.False(t, client.noLimiting)
 }
 
-func TestClient_Options_SetAccessToken(t *testing.T) {
+func TestClient_Options_SetToken(t *testing.T) {
 	client := newClient(t)
 
 	exp := personalToken
-	opt := SetAccessToken(exp)
+	opt := SetToken(exp)
 
 	err := client.Options(opt)
 	assert.NoError(t, err)
 
-	assert.Equal(t, exp, client.config.AccessToken())
+	assert.Equal(t, exp, client.config.Token())
 }
 
 func TestClient_Options_SetClient(t *testing.T) {
@@ -271,7 +271,7 @@ func TestClient_Options_SetPersonalTokenConfig(t *testing.T) {
 	err := client.Options(opt)
 	assert.NoError(t, err)
 
-	assert.Equal(t, personalToken, client.config.AccessToken())
+	assert.Equal(t, personalToken, client.config.Token())
 	assert.Equal(t, organizationID, client.config.OrganizationID())
 }
 
@@ -283,7 +283,7 @@ func TestClient_Options_SetAPITokenConfig(t *testing.T) {
 	err := client.Options(opt)
 	assert.NoError(t, err)
 
-	assert.Equal(t, apiToken, client.config.AccessToken())
+	assert.Equal(t, apiToken, client.config.Token())
 	assert.Empty(t, client.config.OrganizationID())
 }
 
@@ -502,7 +502,7 @@ func TestClient_do_RateLimit(t *testing.T) {
 func TestClient_do_UnprivilegedToken(t *testing.T) {
 	client := setup(t, "/", nil)
 
-	err := client.Options(SetAccessToken("xaat-123"))
+	err := client.Options(SetToken("xaat-123"))
 	require.NoError(t, err)
 
 	_, err = client.NewRequest(context.Background(), http.MethodGet, "/", nil)
@@ -534,7 +534,7 @@ func TestClient_do_ValidOnlyAPITokenPaths(t *testing.T) {
 		t.Run(tt, func(t *testing.T) {
 			client := setup(t, tt, hf)
 
-			err := client.Options(SetAccessToken("xaat-123"))
+			err := client.Options(SetToken("xaat-123"))
 			require.NoError(t, err)
 
 			req, err := client.NewRequest(context.Background(), http.MethodGet, tt, nil)
@@ -694,7 +694,7 @@ func setup(t *testing.T, path string, handler http.HandlerFunc) *Client {
 
 	client, err := NewClient(
 		SetURL(srv.URL),
-		SetAccessToken(personalToken),
+		SetToken(personalToken),
 		SetOrganizationID(organizationID),
 		SetClient(srv.Client()),
 		SetStrictDecoding(true),
@@ -712,7 +712,7 @@ func newClient(t *testing.T) *Client {
 
 	client, err := NewClient(
 		SetURL(endpoint),
-		SetAccessToken(personalToken),
+		SetToken(personalToken),
 		SetNoEnv(),
 	)
 	require.NoError(t, err)

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -57,6 +57,11 @@ const (
 )
 
 // An Event is a map of key-value pairs.
+//
+// If you want to set a timestamp for the event you can either use
+// `ingest.TimestampField` as map key for the timestamp or specify any other
+// field that carries the timestamp by passing `ingest.SetTimestampField` to any
+// of the `Ingest*` methods as an option.
 type Event map[string]any
 
 // Dataset represents an Axiom dataset.
@@ -238,6 +243,12 @@ func (s *DatasetsService) Trim(ctx context.Context, id string, maxDuration time.
 
 // Ingest data into the dataset identified by its id.
 //
+// The timestamp of the events will be set by the server to the current server
+// time if the "_time" field is not set. The server can be instructed to use a
+// different field as the timestamp by setting the `ingest.SetTimestampField`
+// option. If not explicitly specified by `ingest.SetTimestampFormat`, the
+// timestamp format is auto detected.
+//
 // Restrictions for field names (JSON object keys) can be reviewed here:
 // https://www.axiom.co/docs/usage/field-restrictions.
 //
@@ -295,6 +306,12 @@ func (s *DatasetsService) Ingest(ctx context.Context, id string, r io.Reader, ty
 }
 
 // IngestEvents ingests events into the dataset identified by its id.
+//
+// The timestamp of the events will be set by the server to the current server
+// time if the "_time" field is not set. The server can be instructed to use a
+// different field as the timestamp by setting the `ingest.SetTimestampField`
+// option. If not explicitly specified by `ingest.SetTimestampFormat`, the
+// timestamp format is auto detected.
 //
 // Restrictions for field names (JSON object keys) can be reviewed here:
 // https://www.axiom.co/docs/usage/field-restrictions.
@@ -381,6 +398,12 @@ func (s *DatasetsService) IngestEvents(ctx context.Context, id string, events []
 
 // IngestChannel ingests events from a channel into the dataset identified by
 // its id.
+//
+// The timestamp of the events will be set by the server to the current server
+// time if the "_time" field is not set. The server can be instructed to use a
+// different field as the timestamp by setting the `ingest.SetTimestampField`
+// option. If not explicitly specified by `ingest.SetTimestampFormat`, the
+// timestamp format is auto detected.
 //
 // Restrictions for field names (JSON object keys) can be reviewed here:
 // https://www.axiom.co/docs/usage/field-restrictions.

--- a/axiom/doc.go
+++ b/axiom/doc.go
@@ -14,16 +14,26 @@
 // The API token however, will just allow ingestion or querying into or from the
 // datasets the token is valid for, depending on its assigned permissions.
 //
+// To construct a client:
+//
 //	client, err := axiom.NewClient()
+//
+// or with `Options`:
+//
+//	client, err := axiom.NewClient(
+//	  axiom.SetToken("..."),
+//	  axiom.SetOrganizationID("..."),
+//	)
 //
 // Get the current authenticated user:
 //
 //	user, err := client.Users.Current(ctx)
 //
 // NOTE: Every client method mapping to an API method takes a context.Context
-// (https://godoc.org/context) as its first parameter to pass cancelation
+// (https://godoc.org/context) as its first parameter to pass cancellation
 // signals and deadlines to requests. In case there is no context available,
 // then context.Background() can be used as a starting point.
 //
-// For more code samples, check out the https://github.com/axiomhq/axiom-go/tree/main/examples directory.
+// For more code samples, check out the
+// https://github.com/axiomhq/axiom-go/tree/main/examples directory.
 package axiom

--- a/axiom/error_integration_test.go
+++ b/axiom/error_integration_test.go
@@ -28,7 +28,7 @@ func (s *ErrorTestSuite) Test() {
 	s.Require().ErrorIs(err, axiom.ErrNotFound)
 
 	// Set invalid credentials...
-	err = s.client.Options(axiom.SetAccessToken("xapt-123"))
+	err = s.client.Options(axiom.SetToken("xapt-123"))
 	s.Require().NoError(err)
 
 	// ...and see the same request fail with a different error

--- a/axiom/ingest/options.go
+++ b/axiom/ingest/options.go
@@ -1,8 +1,8 @@
 package ingest
 
-// TimestampField is the default field the server looks for a time to use as
-// ingestion time. If not present, the server will set the ingestion time by
-// itself.
+// TimestampField is the default field the server will look for a timestamp to
+// use as the ingestion time. If not present, the server will set the ingestion
+// time to the current server time.
 const TimestampField = "_time"
 
 // Options specifies the optional parameters for ingestion.

--- a/axiom/otel/trace.go
+++ b/axiom/otel/trace.go
@@ -67,11 +67,11 @@ func TraceExporter(ctx context.Context, options ...TraceOption) (trace.SpanExpor
 	if u.Scheme == "http" {
 		opts = append(opts, otlptracehttp.WithInsecure())
 	}
-	if config.AccessToken() != "" || config.OrganizationID() != "" {
+	if config.Token() != "" || config.OrganizationID() != "" {
 		headers := make(map[string]string, 2)
 
-		if config.AccessToken() != "" {
-			headers["Authorization"] = "Bearer " + config.AccessToken()
+		if config.Token() != "" {
+			headers["Authorization"] = "Bearer " + config.Token()
 		}
 		if config.OrganizationID() != "" {
 			headers["X-Axiom-Org-Id"] = config.OrganizationID()

--- a/axiom/otel/trace_config.go
+++ b/axiom/otel/trace_config.go
@@ -38,23 +38,21 @@ func SetURL(baseURL string) TraceOption {
 	return func(c *traceConfig) error { return c.Options(config.SetURL(baseURL)) }
 }
 
-// SetAccessToken specifies the access token to use.
+// SetToken specifies the authentication token used by the client.
 //
 // Can also be specified using the `AXIOM_TOKEN` environment variable.
-func SetAccessToken(accessToken string) TraceOption {
-	return func(c *traceConfig) error { return c.Options(config.SetAccessToken(accessToken)) }
+func SetToken(token string) TraceOption {
+	return func(c *traceConfig) error { return c.Options(config.SetToken(token)) }
 }
 
-// SetOrganizationID specifies the organization ID to use when connecting to
-// Axiom. When a personal access token is used, this method can be used to
-// switch between organizations without creating a new client instance.
+// SetOrganizationID specifies the organization ID used by the client.
 //
 // Can also be specified using the `AXIOM_ORG_ID` environment variable.
 func SetOrganizationID(organizationID string) TraceOption {
 	return func(c *traceConfig) error { return c.Options(config.SetOrganizationID(organizationID)) }
 }
 
-// SetAPIEndpoint sets the api endpoint used by the client.
+// SetAPIEndpoint specifies the api endpoint used by the client.
 func SetAPIEndpoint(path string) TraceOption {
 	return func(c *traceConfig) error {
 		c.APIEndpoint = path
@@ -62,7 +60,7 @@ func SetAPIEndpoint(path string) TraceOption {
 	}
 }
 
-// SetTimeout sets the http timeout used by the client.
+// SetTimeout specifies the http timeout used by the client.
 func SetTimeout(timeout time.Duration) TraceOption {
 	return func(c *traceConfig) error {
 		c.Timeout = timeout
@@ -71,7 +69,7 @@ func SetTimeout(timeout time.Duration) TraceOption {
 }
 
 // SetNoEnv prevents the client from deriving its configuration from the
-// environment (AXIOM_* environment variables).
+// environment (by auto reading "AXIOM_*" environment variables).
 func SetNoEnv() TraceOption {
 	return func(c *traceConfig) error {
 		c.NoEnv = true

--- a/axiom/otel/trace_test.go
+++ b/axiom/otel/trace_test.go
@@ -33,7 +33,7 @@ func TestTracing(t *testing.T) {
 
 	close, err := axiotel.InitTracing(ctx, "axiom-go-otel-test", "v1.0.0",
 		axiotel.SetURL(srv.URL),
-		axiotel.SetAccessToken("xaat-test-token"),
+		axiotel.SetToken("xaat-test-token"),
 		axiotel.SetNoEnv(),
 	)
 	require.NoError(t, err)

--- a/examples/ingestevent/main.go
+++ b/examples/ingestevent/main.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"log"
 	"os"
+	"time"
 
 	"github.com/axiomhq/axiom-go/axiom"
+	"github.com/axiomhq/axiom-go/axiom/ingest"
 )
 
 func main() {
@@ -24,9 +26,13 @@ func main() {
 	}
 
 	// 2. Ingest ⚡
+	//
+	// Set the events timestamp by specifying the "_time" field the server uses
+	// by default. Can be changed by using the `ingest.SetTimestampField` option
+	// when ingesting.
 	events := []axiom.Event{
-		{"foo": "bar"},
-		{"bar": "foo"},
+		{ingest.TimestampField: time.Now(), "foo": "bar"},
+		{ingest.TimestampField: time.Now(), "bar": "foo"},
 	}
 	res, err := client.Datasets.IngestEvents(context.Background(), dataset, events)
 	if err != nil {

--- a/examples/ingestfile/main.go
+++ b/examples/ingestfile/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/axiomhq/axiom-go/axiom"
+	"github.com/axiomhq/axiom-go/axiom/ingest"
 )
 
 func main() {
@@ -40,7 +41,10 @@ func main() {
 	// 4. Ingest ⚡
 	// Note the JSON content type and Gzip content encoding being set because
 	// the client does not auto sense them.
-	res, err := client.Datasets.Ingest(context.Background(), dataset, r, axiom.JSON, axiom.Gzip)
+	res, err := client.Datasets.Ingest(context.Background(), dataset, r, axiom.JSON, axiom.Gzip,
+		// Set a custom timestamp field (default used by the server is "_time").
+		ingest.SetTimestampField("timestamp"),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/ingesthackernews/main.go
+++ b/examples/ingesthackernews/main.go
@@ -87,6 +87,7 @@ func main() {
 
 	// 6. Ingest ⚡
 	res, err := client.Datasets.IngestChannel(ctx, dataset, progressEventCh,
+		// Have the server use the "time" field as the event timestamp.
 		ingest.SetTimestampField("time"),
 	)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,9 +10,9 @@ import (
 type Config struct {
 	// baseURL of the Axiom instance. Defaults to `CloudURL`.
 	baseURL *url.URL
-	// accessToken is the authentication token that will be set as 'Bearer' on
-	// the 'Authorization' header. It must be a personal or an API token.
-	accessToken string
+	// token is the authentication token that will be set as 'Bearer' on the
+	// 'Authorization' header. It must be an API or a personal token.
+	token string
 	// organizationID is the Axiom organization ID that will be set on the
 	// 'X-Axiom-Org-Id' header. Not required for API tokens.
 	organizationID string
@@ -30,9 +30,9 @@ func (c Config) BaseURL() *url.URL {
 	return c.baseURL
 }
 
-// AccessToken returns the access token.
-func (c Config) AccessToken() string {
-	return c.accessToken
+// Token returns the token.
+func (c Config) Token() string {
+	return c.token
 }
 
 // OrganizationID returns the organization ID.
@@ -45,9 +45,9 @@ func (c *Config) SetBaseURL(baseURL *url.URL) {
 	c.baseURL = baseURL
 }
 
-// SetAccessToken sets the access token.
-func (c *Config) SetAccessToken(accessToken string) {
-	c.accessToken = accessToken
+// SetToken sets the token.
+func (c *Config) SetToken(token string) {
+	c.token = token
 }
 
 // SetOrganizationID sets the organization ID.
@@ -70,7 +70,7 @@ func (c *Config) Options(options ...Option) error {
 func (c *Config) IncorporateEnvironment() error {
 	var (
 		envURL            = os.Getenv("AXIOM_URL")
-		envAccessToken    = os.Getenv("AXIOM_TOKEN")
+		envToken          = os.Getenv("AXIOM_TOKEN")
 		envOrganizationID = os.Getenv("AXIOM_ORG_ID")
 
 		options   = make([]Option, 0, 3)
@@ -81,8 +81,8 @@ func (c *Config) IncorporateEnvironment() error {
 		addOption(SetURL(envURL))
 	}
 
-	if envAccessToken != "" {
-		addOption(SetAccessToken(envAccessToken))
+	if envToken != "" {
+		addOption(SetToken(envToken))
 	}
 
 	if envOrganizationID != "" {
@@ -99,14 +99,14 @@ func (c Config) Validate() error {
 		c.baseURL = cloudURL
 	}
 
-	if c.accessToken == "" {
-		return ErrMissingAccessToken
-	} else if !IsValidToken(c.accessToken) {
+	if c.token == "" {
+		return ErrMissingToken
+	} else if !IsValidToken(c.token) {
 		return ErrInvalidToken
 	}
 
 	// The organization ID is not required for API tokens.
-	if c.organizationID == "" && IsPersonalToken(c.accessToken) && c.baseURL.String() == cloudURL.String() {
+	if c.organizationID == "" && IsPersonalToken(c.token) && c.baseURL.String() == cloudURL.String() {
 		return ErrMissingOrganizationID
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,7 +60,7 @@ func TestConfig_IncorporateEnvironment(t *testing.T) {
 			},
 			want: Config{
 				baseURL:        cloudURL,
-				accessToken:    personalToken,
+				token:          personalToken,
 				organizationID: organizationID,
 			},
 		},
@@ -87,19 +87,19 @@ func TestConfig_Validate(t *testing.T) {
 	}{
 		{
 			name:   "no nothing",
-			expErr: ErrMissingAccessToken,
+			expErr: ErrMissingToken,
 		},
 		{
 			name: "missing organization id",
 			config: Config{
-				accessToken: personalToken,
+				token: personalToken,
 			},
 			expErr: ErrMissingOrganizationID,
 		},
 		{
 			name: "missing nothing",
 			config: Config{
-				accessToken:    personalToken,
+				token:          personalToken,
 				organizationID: organizationID,
 			},
 		},

--- a/internal/config/error.go
+++ b/internal/config/error.go
@@ -3,15 +3,16 @@ package config
 import "errors"
 
 var (
-	// ErrMissingAccessToken is raised when an access token is not provided. Set
-	// it manually or export `AXIOM_TOKEN`.
-	ErrMissingAccessToken = errors.New("missing access token")
+	// ErrMissingToken is raised when a token is not provided. Set it manually
+	// using the `axiom.SetToken` option when constructing a client or export
+	// `AXIOM_TOKEN`.
+	ErrMissingToken = errors.New("missing token")
 
 	// ErrMissingOrganizationID is raised when an organization ID is not
-	// provided. Set it manually using the SetOrgID option or export
-	// `AXIOM_ORG_ID`.
+	// provided. Set it manually using the `axiom.SetOrganizationID` option when
+	// constructing a client or export `AXIOM_ORG_ID`.
 	ErrMissingOrganizationID = errors.New("missing organization id")
 
-	// ErrInvalidToken is returned when the access token is invalid.
-	ErrInvalidToken = errors.New("invalid access token")
+	// ErrInvalidToken is returned when the token is invalid.
+	ErrInvalidToken = errors.New("invalid token")
 )

--- a/internal/config/option.go
+++ b/internal/config/option.go
@@ -5,7 +5,7 @@ import "net/url"
 // An Option modifies the configuration. It is not safe for concurrent use.
 type Option func(config *Config) error
 
-// SetURL sets the base URL to use.
+// SetURL specifies the base URL to use.
 func SetURL(baseURL string) Option {
 	return func(config *Config) (err error) {
 		baseURL, err := url.ParseRequestURI(baseURL)
@@ -19,14 +19,14 @@ func SetURL(baseURL string) Option {
 	}
 }
 
-// SetAccessToken specifies the access token to use.
-func SetAccessToken(accessToken string) Option {
+// SetToken specifies the token to use.
+func SetToken(token string) Option {
 	return func(config *Config) error {
-		if !IsValidToken(accessToken) {
+		if !IsValidToken(token) {
 			return ErrInvalidToken
 		}
 
-		config.SetAccessToken(accessToken)
+		config.SetToken(token)
 
 		return nil
 	}

--- a/internal/test/adapters/integration.go
+++ b/internal/test/adapters/integration.go
@@ -60,7 +60,7 @@ func IntegrationTest(t *testing.T, adapterName string, testFunc IntegrationTestF
 	client, err := axiom.NewClient(
 		axiom.SetNoEnv(),
 		axiom.SetURL(cfg.BaseURL().String()),
-		axiom.SetAccessToken(cfg.AccessToken()),
+		axiom.SetToken(cfg.Token()),
 		axiom.SetOrganizationID(cfg.OrganizationID()),
 		axiom.SetUserAgent(userAgent),
 	)

--- a/internal/test/adapters/unit.go
+++ b/internal/test/adapters/unit.go
@@ -22,7 +22,7 @@ func Setup[T any](t *testing.T, hf http.HandlerFunc, setupFunc func(dataset stri
 	client, err := axiom.NewClient(
 		axiom.SetNoEnv(),
 		axiom.SetURL(srv.URL),
-		axiom.SetAccessToken("xaat-test"),
+		axiom.SetToken("xaat-test"),
 		axiom.SetClient(srv.Client()),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR improves the documentation and examples:

* Rename occurences of "access token" -> "token"
* Improve GoDoc on specifying a timestamp
* Improve examples on specifiying a timestamp
* Improve README on specifying a timestamp
* Improve README by specifying correct import path
* Improve GoDoc by giving an example on configuration options
* General doc fixes by aligning wording

Closes #169.