### PR TITLE
Top-level aliases for ingest and query methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ func main() {
         log.Fatalln(err)
     }
     
-    if _, err = client.Datasets.IngestEvents(ctx, "my-dataset", []axiom.Event{
+    if _, err = client.IngestEvents(ctx, "my-dataset", []axiom.Event{
         {ingest.TimestampField: time.Now(), "foo": "bar"},
         {ingest.TimestampField: time.Now(), "bar": "foo"},
     }); err != nil {
         log.Fatalln(err)
     }
 
-    res, err := client.Datasets.Query(ctx, "['my-dataset'] | where foo == 'bar' | limit 100")
+    res, err := client.Query(ctx, "['my-dataset'] | where foo == 'bar' | limit 100")
     if err != nil {
         log.Fatalln(err)
     }

--- a/adapters/apex/apex.go
+++ b/adapters/apex/apex.go
@@ -124,7 +124,7 @@ func New(options ...Option) (*Handler, error) {
 
 		logger := stdlog.New(os.Stderr, "[AXIOM|APEX]", 0)
 
-		res, err := handler.client.Datasets.IngestChannel(context.Background(), handler.datasetName, handler.eventCh, handler.ingestOptions...)
+		res, err := handler.client.IngestChannel(context.Background(), handler.datasetName, handler.eventCh, handler.ingestOptions...)
 		if err != nil {
 			logger.Printf("failed to ingest events: %s\n", err)
 		} else if res.Failed > 0 {

--- a/adapters/logrus/logrus.go
+++ b/adapters/logrus/logrus.go
@@ -136,7 +136,7 @@ func New(options ...Option) (*Hook, error) {
 
 		logger := stdlog.New(os.Stderr, "[AXIOM|LOGRUS]", 0)
 
-		res, err := hook.client.Datasets.IngestChannel(context.Background(), hook.datasetName, hook.eventCh, hook.ingestOptions...)
+		res, err := hook.client.IngestChannel(context.Background(), hook.datasetName, hook.eventCh, hook.ingestOptions...)
 		if err != nil {
 			logger.Printf("failed to ingest events: %s\n", err)
 		} else if res.Failed > 0 {

--- a/adapters/zap/zap.go
+++ b/adapters/zap/zap.go
@@ -176,7 +176,7 @@ func (ws *WriteSyncer) Sync() error {
 		return err
 	}
 
-	res, err := ws.client.Datasets.Ingest(ctx, ws.datasetName, r, axiom.NDJSON, axiom.Zstd, ws.ingestOptions...)
+	res, err := ws.client.Ingest(ctx, ws.datasetName, r, axiom.NDJSON, axiom.Zstd, ws.ingestOptions...)
 	if err != nil {
 		return err
 	} else if res.Failed > 0 {

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -250,8 +250,8 @@ func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 			}
 			resp = newResponse(httpResp)
 
-			// We should only retry in the case the status code is >= 500, anything
-			// below isn't worth retrying.
+			// We should only retry in the case the status code is >= 500,
+			// anything below isn't worth retrying.
 			if code := resp.StatusCode; code >= 500 {
 				_, _ = io.Copy(io.Discard, resp.Body)
 				_ = resp.Body.Close()

--- a/axiom/client_test.go
+++ b/axiom/client_test.go
@@ -413,6 +413,22 @@ func TestClient_do_HTTPError(t *testing.T) {
 	}
 }
 
+func TestClient_do_HTTPError_Typed(t *testing.T) {
+	hf := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(http.StatusText(http.StatusForbidden)))
+	}
+
+	client := setup(t, "/", hf)
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	if _, err = client.Do(req, nil); assert.ErrorIs(t, err, ErrUnauthorized) {
+		assert.EqualError(t, err, "insufficient permissions")
+	}
+}
+
 func TestClient_do_HTTPError_JSON(t *testing.T) {
 	hf := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", mediaTypeJSON)

--- a/examples/ingestevent/main.go
+++ b/examples/ingestevent/main.go
@@ -34,7 +34,7 @@ func main() {
 		{ingest.TimestampField: time.Now(), "foo": "bar"},
 		{ingest.TimestampField: time.Now(), "bar": "foo"},
 	}
-	res, err := client.Datasets.IngestEvents(context.Background(), dataset, events)
+	res, err := client.IngestEvents(context.Background(), dataset, events)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/ingestfile/main.go
+++ b/examples/ingestfile/main.go
@@ -42,7 +42,7 @@ func main() {
 	// 4. Ingest ⚡
 	// Note the JSON content type and Gzip content encoding being set because
 	// the client does not auto sense them.
-	res, err := client.Datasets.Ingest(context.Background(), dataset, r, axiom.JSON, axiom.Gzip,
+	res, err := client.Ingest(context.Background(), dataset, r, axiom.JSON, axiom.Gzip,
 		// Set a custom timestamp field (default used by the server is "_time").
 		ingest.SetTimestampField("timestamp"),
 	)

--- a/examples/ingesthackernews/main.go
+++ b/examples/ingesthackernews/main.go
@@ -86,7 +86,7 @@ func main() {
 	}
 
 	// 6. Ingest ⚡
-	res, err := client.Datasets.IngestChannel(ctx, dataset, progressEventCh,
+	res, err := client.IngestChannel(ctx, dataset, progressEventCh,
 		// Have the server use the "time" field as the event timestamp.
 		ingest.SetTimestampField("time"),
 	)

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	// 2. Query all events using APL ⚡
 	apl := fmt.Sprintf("['%s']", dataset) // E.g. ['test']
-	res, err := client.Datasets.Query(context.Background(), apl)
+	res, err := client.Query(context.Background(), apl)
 	if err != nil {
 		log.Fatal(err)
 	} else if len(res.Matches) == 0 {

--- a/examples/querylegacy/main.go
+++ b/examples/querylegacy/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	// 2. Query all events in the last minute ⚡
-	res, err := client.Datasets.QueryLegacy(context.Background(), dataset, querylegacy.Query{
+	res, err := client.QueryLegacy(context.Background(), dataset, querylegacy.Query{
 		StartTime: time.Now().Add(-time.Minute),
 		EndTime:   time.Now(),
 	}, querylegacy.Options{})


### PR DESCRIPTION
This PR adds aliases for ingest and query methods on the `Client`. It is just an alias and uses the implementation on the `DatasetsService` but it keeps the full GoDoc comment for ease-of-use with autocomplete functionality.