### PR TITLE
fix(query): support compiler warning message codes

### DIFF
--- a/adapters/apex/apex_test.go
+++ b/adapters/apex/apex_test.go
@@ -2,7 +2,6 @@ package apex
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -56,7 +55,7 @@ func TestHandler(t *testing.T) {
 		b, err := io.ReadAll(zsr)
 		assert.NoError(t, err)
 
-		JSONEqExp(t, exp, string(b), []string{ingest.TimestampField})
+		testhelper.JSONEqExp(t, exp, string(b), []string{ingest.TimestampField})
 
 		atomic.AddUint64(&hasRun, 1)
 
@@ -129,32 +128,4 @@ func setup(t *testing.T) func(dataset string, client *axiom.Client) *log.Logger 
 
 		return logger
 	}
-}
-
-// JSONEqExp is like assert.JSONEq() but excludes the given fields.
-func JSONEqExp(t assert.TestingT, expected string, actual string, excludedFields []string, msgAndArgs ...any) bool {
-	type tHelper interface {
-		Helper()
-	}
-
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
-
-	var expectedJSONAsInterface, actualJSONAsInterface map[string]any
-
-	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {
-		return assert.Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)
-	}
-
-	if err := json.Unmarshal([]byte(actual), &actualJSONAsInterface); err != nil {
-		return assert.Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
-	}
-
-	for _, excludedField := range excludedFields {
-		delete(expectedJSONAsInterface, excludedField)
-		delete(actualJSONAsInterface, excludedField)
-	}
-
-	return assert.Equal(t, expectedJSONAsInterface, actualJSONAsInterface, msgAndArgs...)
 }

--- a/axiom/query/result.go
+++ b/axiom/query/result.go
@@ -3,6 +3,7 @@ package query
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -19,9 +20,17 @@ const (
 	MissingColumn               // missing_column
 	LicenseLimitForQueryWarning // license_limit_for_query_warning
 	DefaultLimitWarning         // default_limit_warning
+
+	// CompilerWarning is a generic code. Please inspect the message text for
+	// more details.
+	CompilerWarning // apl_
 )
 
 func messageCodeFromString(s string) (mc MessageCode, err error) {
+	if strings.HasPrefix(s, CompilerWarning.String()) {
+		return CompilerWarning, nil
+	}
+
 	switch s {
 	case emptyMessageCode.String():
 		mc = emptyMessageCode

--- a/axiom/query/result_string.go
+++ b/axiom/query/result_string.go
@@ -13,11 +13,12 @@ func _() {
 	_ = x[MissingColumn-2]
 	_ = x[LicenseLimitForQueryWarning-3]
 	_ = x[DefaultLimitWarning-4]
+	_ = x[CompilerWarning-5]
 }
 
-const _MessageCode_name = "virtual_field_finalize_errormissing_columnlicense_limit_for_query_warningdefault_limit_warning"
+const _MessageCode_name = "virtual_field_finalize_errormissing_columnlicense_limit_for_query_warningdefault_limit_warningapl_"
 
-var _MessageCode_index = [...]uint8{0, 0, 28, 42, 73, 94}
+var _MessageCode_index = [...]uint8{0, 0, 28, 42, 73, 94, 98}
 
 func (i MessageCode) String() string {
 	if i >= MessageCode(len(_MessageCode_index)-1) {

--- a/axiom/querylegacy/result.go
+++ b/axiom/querylegacy/result.go
@@ -3,6 +3,7 @@ package querylegacy
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -19,9 +20,17 @@ const (
 	MissingColumn               // missing_column
 	LicenseLimitForQueryWarning // license_limit_for_query_warning
 	DefaultLimitWarning         // default_limit_warning
+
+	// CompilerWarning is a generic code. Please inspect the message text for
+	// more details.
+	CompilerWarning // apl_
 )
 
 func messageCodeFromString(s string) (mc MessageCode, err error) {
+	if strings.HasPrefix(s, CompilerWarning.String()) {
+		return CompilerWarning, nil
+	}
+
 	switch s {
 	case emptyMessageCode.String():
 		mc = emptyMessageCode

--- a/axiom/querylegacy/result_string.go
+++ b/axiom/querylegacy/result_string.go
@@ -13,11 +13,12 @@ func _() {
 	_ = x[MissingColumn-2]
 	_ = x[LicenseLimitForQueryWarning-3]
 	_ = x[DefaultLimitWarning-4]
+	_ = x[CompilerWarning-5]
 }
 
-const _MessageCode_name = "virtual_field_finalize_errormissing_columnlicense_limit_for_query_warningdefault_limit_warning"
+const _MessageCode_name = "virtual_field_finalize_errormissing_columnlicense_limit_for_query_warningdefault_limit_warningapl_"
 
-var _MessageCode_index = [...]uint8{0, 0, 28, 42, 73, 94}
+var _MessageCode_index = [...]uint8{0, 0, 28, 42, 73, 94, 98}
 
 func (i MessageCode) String() string {
 	if i >= MessageCode(len(_MessageCode_index)-1) {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.2
+	github.com/tidwall/sjson v1.2.5
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.40.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0
 	go.opentelemetry.io/otel v1.14.0
@@ -173,6 +174,9 @@ require (
 	github.com/t-yuki/gocover-cobertura v0.0.0-20180217150009-aaee18c8195c // indirect
 	github.com/tdakkota/asciicheck v0.2.0 // indirect
 	github.com/tetafro/godot v1.4.11 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/timakin/bodyclose v0.0.0-20221125081123-e39cf3fc478e // indirect
 	github.com/timonwong/loggercheck v0.9.4 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -596,6 +596,15 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.4.11 h1:BVoBIqAf/2QdbFmSwAWnaIqDivZdOV0ZRwEm6jivLKw=
 github.com/tetafro/godot v1.4.11/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/timakin/bodyclose v0.0.0-20221125081123-e39cf3fc478e h1:MV6KaVu/hzByHP0UvJ4HcMGE/8a6A4Rggc/0wx2AvJo=
 github.com/timakin/bodyclose v0.0.0-20221125081123-e39cf3fc478e/go.mod h1:27bSVNWSBOHm+qRp1T9qzaIpsWEP6TbUnei/43HK+PQ=
 github.com/timonwong/loggercheck v0.9.4 h1:HKKhqrjcVj8sxL7K77beXh0adEm6DLjV/QOGeMXEVi4=

--- a/internal/test/testhelper/json.go
+++ b/internal/test/testhelper/json.go
@@ -1,0 +1,29 @@
+package testhelper
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/sjson"
+)
+
+// JSONEqExp is like assert.JSONEq() but excludes the given fields (given in
+// sjson notation: https://github.com/tidwall/sjson).
+func JSONEqExp(t assert.TestingT, expected string, actual string, excludedFields []string, msgAndArgs ...any) bool {
+	type tHelper interface {
+		Helper()
+	}
+
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	for _, excludedField := range excludedFields {
+		var err error
+		if expected, err = sjson.Delete(expected, excludedField); err != nil {
+			return assert.Error(t, err)
+		} else if actual, err = sjson.Delete(actual, excludedField); err != nil {
+			return assert.Error(t, err)
+		}
+	}
+
+	return assert.JSONEq(t, expected, actual, msgAndArgs...)
+}


### PR DESCRIPTION
A Discord community user reported a failed CLI query. It became clear that the failure was caused by Axiom Go not being able to decode the query response because of an unknown message code (compiler warning).

This adds a generic code for compiler warnigns (they all start with `apl_`) as they are dynamic but most of the changes are in place to support/enhance unit testing.

It can be debated if this approach still makes sense for dynamically created message codes but this PR only fixes the error observed.

In the future we might have a `map[Code]Message` where `Code` is just any string error code.