### PR TITLE
chore(options): don't panic when 'nil' is passed as an option

### DIFF
--- a/adapters/apex/apex.go
+++ b/adapters/apex/apex.go
@@ -97,7 +97,9 @@ func New(options ...Option) (*Handler, error) {
 
 	// Apply supplied options.
 	for _, option := range options {
-		if err := option(handler); err != nil {
+		if option == nil {
+			continue
+		} else if err := option(handler); err != nil {
 			return nil, err
 		}
 	}

--- a/adapters/logrus/logrus.go
+++ b/adapters/logrus/logrus.go
@@ -109,7 +109,9 @@ func New(options ...Option) (*Hook, error) {
 
 	// Apply supplied options.
 	for _, option := range options {
-		if err := option(hook); err != nil {
+		if option == nil {
+			continue
+		} else if err := option(hook); err != nil {
 			return nil, err
 		}
 	}

--- a/adapters/slog/slog.go
+++ b/adapters/slog/slog.go
@@ -118,7 +118,9 @@ func New(options ...Option) (*Handler, error) {
 
 	// Apply supplied options.
 	for _, option := range options {
-		if err := option(handler); err != nil {
+		if option == nil {
+			continue
+		} else if err := option(handler); err != nil {
 			return nil, err
 		}
 	}

--- a/adapters/zap/zap.go
+++ b/adapters/zap/zap.go
@@ -122,7 +122,9 @@ func New(options ...Option) (zapcore.Core, error) {
 
 	// Apply supplied options.
 	for _, option := range options {
-		if err := option(ws); err != nil {
+		if option == nil {
+			continue
+		} else if err := option(ws); err != nil {
 			return nil, err
 		}
 	}

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -146,7 +146,9 @@ func NewClient(options ...Option) (*Client, error) {
 // Options applies options to the client.
 func (c *Client) Options(options ...Option) error {
 	for _, option := range options {
-		if err := option(c); err != nil {
+		if option == nil {
+			continue
+		} else if err := option(c); err != nil {
 			return err
 		}
 	}

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -325,7 +325,9 @@ func (s *DatasetsService) Ingest(ctx context.Context, id string, r io.Reader, ty
 	// Apply supplied options.
 	var opts ingest.Options
 	for _, option := range options {
-		option(&opts)
+		if option != nil {
+			option(&opts)
+		}
 	}
 
 	path, err := url.JoinPath(s.basePath, id, "ingest")
@@ -396,7 +398,9 @@ func (s *DatasetsService) IngestEvents(ctx context.Context, id string, events []
 	// Apply supplied options.
 	var opts ingest.Options
 	for _, option := range options {
-		option(&opts)
+		if option != nil {
+			option(&opts)
+		}
 	}
 
 	if len(events) == 0 {
@@ -572,7 +576,9 @@ func (s *DatasetsService) Query(ctx context.Context, apl string, options ...quer
 	// Apply supplied options.
 	var opts query.Options
 	for _, option := range options {
-		option(&opts)
+		if option != nil {
+			option(&opts)
+		}
 	}
 
 	ctx, span := s.client.trace(ctx, "Datasets.Query", trace.WithAttributes(

--- a/axiom/otel/trace.go
+++ b/axiom/otel/trace.go
@@ -39,7 +39,9 @@ func TraceExporter(ctx context.Context, dataset string, options ...TraceOption) 
 
 	// Apply supplied options.
 	for _, option := range options {
-		if err := option(&config); err != nil {
+		if option == nil {
+			continue
+		} else if err := option(&config); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,7 +58,9 @@ func (c *Config) SetOrganizationID(organizationID string) {
 // Options applies options to the configuration.
 func (c *Config) Options(options ...Option) error {
 	for _, option := range options {
-		if err := option(c); err != nil {
+		if option == nil {
+			continue
+		} else if err := option(c); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Just a simple quality of life improvent that prevents users from cauing a panic when accidentally passing `nil` as a configuration option.