### PR TITLE
fix(slogx): adapter name

### DIFF
--- a/adapters/slogx/slog_integration_test.go
+++ b/adapters/slogx/slog_integration_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Test(t *testing.T) {
-	adapters.IntegrationTest(t, "slog", func(_ context.Context, dataset string, client *axiom.Client) {
+	adapters.IntegrationTest(t, "slogx", func(_ context.Context, dataset string, client *axiom.Client) {
 		handler, err := adapter.New(
 			adapter.SetClient(client),
 			adapter.SetDataset(dataset),


### PR DESCRIPTION
The `slog` and `slogx` adapter packages are 100% the same code but share different imports (as `slog` just recently became part of the stdlib in Go 1.21).

But the same adapter name causes the integration test to fail as the dataset name for the test is dereived from the adapter name.

So just making sure we have unique names, here.