### PR TITLE
feat(client): option to disable tracing

### DIFF
--- a/axiom/client_options.go
+++ b/axiom/client_options.go
@@ -3,6 +3,8 @@ package axiom
 import (
 	"net/http"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/axiomhq/axiom-go/internal/config"
 )
 
@@ -87,6 +89,15 @@ func SetNoEnv() Option {
 func SetNoRetry() Option {
 	return func(c *Client) error {
 		c.noRetry = true
+		return nil
+	}
+}
+
+// SetNoTracing prevents the [Client] from acquiring a tracer from the global
+// tracer provider, even if one is configured.
+func SetNoTracing() Option {
+	return func(c *Client) error {
+		c.tracer = trace.NewNoopTracerProvider().Tracer(otelTracerName)
 		return nil
 	}
 }


### PR DESCRIPTION
One of the nice features of the OTEL SDK for Go is, that - once configured - tracers are globally available. This way Axiom Go will be traced once a package user decides to setup OTEL.

However, this also means the client will be traced in that case, even if not explicitly wanted by the user. The new `NoTracing()` option sets a `noop` tracer on the client to disable this behaviour.