### PR TITLE
chore(monitors): updated monitors to pass in resolvable flag which is required by the API

### DIFF
--- a/axiom/monitors.go
+++ b/axiom/monitors.go
@@ -74,6 +74,9 @@ type Monitor struct {
 	AlertOnNoData bool `json:"alertOnNoData"`
 	// NotifyByGroup tracks each none-time group independently
 	NotifyByGroup bool `json:"notifyByGroup"`
+	// Resolvable determines whether the events triggered by the monitor
+	// are resolvable. This has no effect on threshold monitors
+	Resolvable bool `json:"resolvable"`
 	// APLQuery is the APL query to use for the monitor.
 	APLQuery string `json:"aplQuery"`
 	// Description of the monitor.


### PR DESCRIPTION
Have removed `err = fmt.Errorf("unknown comparison %q", s)`, as UI will contain some operators not present in this library and it saves breaking the integration specs.