### PR TITLE
feat: increase default batch size from 1k to 10k

### DIFF
--- a/adapters/apex/apex.go
+++ b/adapters/apex/apex.go
@@ -16,7 +16,7 @@ import (
 
 var _ log.Handler = (*Handler)(nil)
 
-const defaultBatchSize = 1000
+const defaultBatchSize = 10_000
 
 // ErrMissingDatasetName is raised when a dataset name is not provided. Set it
 // manually using the [SetDataset] option or export "AXIOM_DATASET".

--- a/adapters/apex/apex_test.go
+++ b/adapters/apex/apex_test.go
@@ -72,47 +72,6 @@ func TestHandler(t *testing.T) {
 	assert.EqualValues(t, 1, atomic.LoadUint64(&hasRun))
 }
 
-func TestHandler_FlushFullBatch(t *testing.T) {
-	exp := fmt.Sprintf(`{"_time":"%s","severity":"info","key":"value","message":"my message"}`,
-		time.Now().Format(time.RFC3339Nano))
-
-	var lines uint64
-	hf := func(w http.ResponseWriter, r *http.Request) {
-		zsr, err := zstd.NewReader(r.Body)
-		require.NoError(t, err)
-
-		s := bufio.NewScanner(zsr)
-		for s.Scan() {
-			testhelper.JSONEqExp(t, exp, s.Text(), []string{ingest.TimestampField})
-			atomic.AddUint64(&lines, 1)
-		}
-		assert.NoError(t, s.Err())
-
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte("{}"))
-	}
-
-	logger, _ := adapters.Setup(t, hf, setup(t))
-
-	for i := 0; i <= 1000; i++ {
-		logger.
-			WithField("key", "value").
-			Info("my message")
-	}
-
-	// Let the server process.
-	time.Sleep(time.Millisecond * 250)
-
-	// Should have a full batch right away.
-	assert.EqualValues(t, 1000, atomic.LoadUint64(&lines))
-
-	// Wait for timer based handler flush.
-	time.Sleep(time.Second + time.Millisecond*250)
-
-	// Should have received the last event.
-	assert.EqualValues(t, 1001, atomic.LoadUint64(&lines))
-}
-
 func TestHandler_NoPanicAfterClose(t *testing.T) {
 	exp := fmt.Sprintf(`{"_time":"%s","severity":"info","key":"value","message":"my message"}`,
 		time.Now().Format(time.RFC3339Nano))

--- a/adapters/logrus/logrus.go
+++ b/adapters/logrus/logrus.go
@@ -16,7 +16,7 @@ import (
 
 var _ logrus.Hook = (*Hook)(nil)
 
-const defaultBatchSize = 1000
+const defaultBatchSize = 10_000
 
 // ErrMissingDatasetName is raised when a dataset name is not provided. Set it
 // manually using the [SetDataset] option or export "AXIOM_DATASET".

--- a/adapters/slog/slog.go
+++ b/adapters/slog/slog.go
@@ -16,7 +16,7 @@ import (
 
 var _ slog.Handler = (*Handler)(nil)
 
-const defaultBatchSize = 1000
+const defaultBatchSize = 10_000
 
 // ErrMissingDatasetName is raised when a dataset name is not provided. Set it
 // manually using the [SetDataset] option or export "AXIOM_DATASET".

--- a/adapters/slog/slog_test.go
+++ b/adapters/slog/slog_test.go
@@ -72,47 +72,6 @@ func TestHandler(t *testing.T) {
 	assert.EqualValues(t, 1, atomic.LoadUint64(&hasRun))
 }
 
-func TestHandler_FlushFullBatch(t *testing.T) {
-	exp := fmt.Sprintf(`{"_time":"%s","level":"INFO","key":"value","msg":"my message"}`,
-		time.Now().Format(time.RFC3339Nano))
-
-	var lines uint64
-	hf := func(w http.ResponseWriter, r *http.Request) {
-		zsr, err := zstd.NewReader(r.Body)
-		require.NoError(t, err)
-
-		s := bufio.NewScanner(zsr)
-		for s.Scan() {
-			atomic.AddUint64(&lines, 1)
-			testhelper.JSONEqExp(t, exp, s.Text(), []string{ingest.TimestampField})
-		}
-		assert.NoError(t, s.Err())
-
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte("{}"))
-	}
-
-	logger, _ := adapters.Setup(t, hf, setup(t))
-
-	for i := 0; i <= 1000; i++ {
-		logger.
-			With("key", "value").
-			Info("my message")
-	}
-
-	// Let the server process.
-	time.Sleep(time.Millisecond * 250)
-
-	// Should have a full batch right away.
-	assert.EqualValues(t, 1000, atomic.LoadUint64(&lines))
-
-	// Wait for timer based hook flush.
-	time.Sleep(time.Second + time.Millisecond*250)
-
-	// Should have received the last event.
-	assert.EqualValues(t, 1001, atomic.LoadUint64(&lines))
-}
-
 func TestHandler_NoPanicAfterClose(t *testing.T) {
 	exp := fmt.Sprintf(`{"_time":"%s","level":"INFO","key":"value","msg":"my message"}`,
 		time.Now().Format(time.RFC3339Nano))

--- a/adapters/zerolog/zerolog.go
+++ b/adapters/zerolog/zerolog.go
@@ -29,7 +29,7 @@ var (
 )
 
 const (
-	defaultBatchSize = 1000
+	defaultBatchSize = 10_000
 	flushInterval    = time.Second
 )
 

--- a/adapters/zerolog/zerolog_test.go
+++ b/adapters/zerolog/zerolog_test.go
@@ -93,21 +93,21 @@ func TestHook_FlushFullBatch(t *testing.T) {
 
 	logger, _ := adapters.Setup(t, hf, setup(t))
 
-	for i := 0; i <= 1000; i++ {
+	for i := 0; i <= 10_000; i++ {
 		logger.Info().Str("key", "value").Msg("my message")
 	}
 
 	// Let the server process.
-	time.Sleep(time.Millisecond * 250)
+	time.Sleep(time.Millisecond * 750)
 
 	// Should have a full batch right away.
-	assert.EqualValues(t, 1000, atomic.LoadUint64(&lines))
+	assert.EqualValues(t, 10_000, atomic.LoadUint64(&lines))
 
 	// Wait for timer based hook flush.
 	time.Sleep(time.Second + time.Millisecond*250)
 
 	// Should have received the last event.
-	assert.EqualValues(t, 1001, atomic.LoadUint64(&lines))
+	assert.EqualValues(t, 10_001, atomic.LoadUint64(&lines))
 }
 
 func setup(t *testing.T) func(dataset string, client *axiom.Client) (*zerolog.Logger, func()) {

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -424,9 +424,9 @@ func (c *Client) IngestEvents(ctx context.Context, id string, events []Event, op
 // Restrictions for field names (JSON object keys) can be reviewed in
 // [our documentation].
 //
-// Events are ingested in batches. A batch is either 1000 events for unbuffered
+// Events are ingested in batches. A batch is either 10000 events for unbuffered
 // channels or the capacity of the channel for buffered channels. The maximum
-// batch size is 1000. A batch is sent to the server as soon as it is full,
+// batch size is 10000. A batch is sent to the server as soon as it is full,
 // after one second or when the channel is closed.
 //
 // The method returns with an error when the context is marked as done or an

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -495,9 +495,9 @@ func (s *DatasetsService) IngestEvents(ctx context.Context, id string, events []
 // Restrictions for field names (JSON object keys) can be reviewed in
 // [our documentation].
 //
-// Events are ingested in batches. A batch is either 1000 events for unbuffered
+// Events are ingested in batches. A batch is either 10000 events for unbuffered
 // channels or the capacity of the channel for buffered channels. The maximum
-// batch size is 1000. A batch is sent to the server as soon as it is full,
+// batch size is 10000. A batch is sent to the server as soon as it is full,
 // after one second or when the channel is closed.
 //
 // The method returns with an error when the context is marked as done or an
@@ -520,9 +520,9 @@ func (s *DatasetsService) IngestChannel(ctx context.Context, id string, events <
 	))
 	defer span.End()
 
-	// Batch is either 1000 events for unbuffered channels or the capacity of
-	// the channel for buffered channels. The maximum batch size is 1000.
-	batchSize := 1000
+	// Batch is either 10000 events for unbuffered channels or the capacity of
+	// the channel for buffered channels. The maximum batch size is 10000.
+	batchSize := 10_000
 	if cap(events) > 0 && cap(events) <= batchSize {
 		batchSize = cap(events)
 	}


### PR DESCRIPTION
1k is pretty conservative so we increase the default batch size to 10k.

I also dropped the tests that were validating batching behaviour for all the adapters that are based on `IngestChannel()`, which has it's own set of tests in the library to make sure it batches as intended. 