### PR TITLE
chore/fix: integration test suits cleanups + 'url.JoinPath' cleanups

### DIFF
--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -250,7 +250,7 @@ func (s *DatasetsService) Delete(ctx context.Context, id string) error {
 	))
 	defer span.End()
 
-	path, err := url.JoinPath(s.basePath, "/", id)
+	path, err := url.JoinPath(s.basePath, id)
 	if err != nil {
 		return spanError(span, err)
 	}
@@ -319,6 +319,7 @@ func (s *DatasetsService) Ingest(ctx context.Context, id string, r io.Reader, ty
 		}
 	}
 
+	// TODO(lukasmalkmus): Use 's.basePath' once ingest v2 is available.
 	path, err := url.JoinPath("/v1/datasets", id, "ingest")
 	if err != nil {
 		return nil, spanError(span, err)
@@ -400,6 +401,7 @@ func (s *DatasetsService) IngestEvents(ctx context.Context, id string, events []
 		}
 	}
 
+	// TODO(lukasmalkmus): Use 's.basePath' once ingest v2 is available.
 	path, err := url.JoinPath("/v1/datasets", id, "ingest")
 	if err != nil {
 		return nil, spanError(span, err)
@@ -599,6 +601,7 @@ func (s *DatasetsService) Query(ctx context.Context, apl string, options ...quer
 		Format: "legacy", // Hardcode legacy APL format for now.
 	}
 
+	// TODO(lukasmalkmus): Use 's.basePath' once ingest v2 is available.
 	path, err := url.JoinPath("/v1/datasets", "_apl")
 	if err != nil {
 		return nil, spanError(span, err)

--- a/axiom/datasets_integration_test.go
+++ b/axiom/datasets_integration_test.go
@@ -77,6 +77,7 @@ var ingestEvents = []axiom.Event{
 type DatasetsTestSuite struct {
 	IntegrationTestSuite
 
+	// Setup once per test.
 	dataset *axiom.Dataset
 }
 
@@ -84,19 +85,11 @@ func TestDatasetsTestSuite(t *testing.T) {
 	suite.Run(t, new(DatasetsTestSuite))
 }
 
-func (s *DatasetsTestSuite) SetupSuite() {
-	s.IntegrationTestSuite.SetupSuite()
-}
-
-func (s *DatasetsTestSuite) TearDownSuite() {
-	s.IntegrationTestSuite.TearDownSuite()
-}
-
 func (s *DatasetsTestSuite) SetupTest() {
 	s.IntegrationTestSuite.SetupTest()
 
 	var err error
-	s.dataset, err = s.client.Datasets.Create(s.suiteCtx, axiom.DatasetCreateRequest{
+	s.dataset, err = s.client.Datasets.Create(s.ctx, axiom.DatasetCreateRequest{
 		Name:        "test-axiom-go-datasets-" + datasetSuffix,
 		Description: "This is a test dataset for datasets integration tests.",
 	})
@@ -107,7 +100,7 @@ func (s *DatasetsTestSuite) SetupTest() {
 func (s *DatasetsTestSuite) TearDownTest() {
 	// Teardown routines use their own context to avoid not being run at all
 	// when the suite gets cancelled or times out.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), time.Second*15)
 	defer cancel()
 
 	err := s.client.Datasets.Delete(ctx, s.dataset.ID)

--- a/axiom/monitors.go
+++ b/axiom/monitors.go
@@ -222,7 +222,7 @@ func (s *MonitorsService) Delete(ctx context.Context, id string) error {
 	))
 	defer span.End()
 
-	path, err := url.JoinPath(s.basePath, "/", id)
+	path, err := url.JoinPath(s.basePath, id)
 	if err != nil {
 		return spanError(span, err)
 	}

--- a/axiom/monitors.go
+++ b/axiom/monitors.go
@@ -128,8 +128,8 @@ func (m *Monitor) UnmarshalJSON(b []byte) error {
 
 	// Set to a proper time.Duration value by interpreting the server response
 	// value in seconds.
-	m.Range = m.Range * time.Minute
-	m.Interval = m.Interval * time.Minute
+	m.Range *= time.Minute
+	m.Interval *= time.Minute
 
 	return nil
 }

--- a/axiom/notifiers.go
+++ b/axiom/notifiers.go
@@ -164,7 +164,7 @@ func (s *NotifiersService) Delete(ctx context.Context, id string) error {
 	))
 	defer span.End()
 
-	path, err := url.JoinPath(s.basePath, "/", id)
+	path, err := url.JoinPath(s.basePath, id)
 	if err != nil {
 		return spanError(span, err)
 	}

--- a/axiom/notifiers_integration_test.go
+++ b/axiom/notifiers_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package axiom_test
 
 import (
@@ -17,6 +15,7 @@ import (
 type NotifiersTestSuite struct {
 	IntegrationTestSuite
 
+	// Setup once per test.
 	notifier *axiom.Notifier
 }
 
@@ -26,9 +25,17 @@ func TestNotifiersTestSuite(t *testing.T) {
 
 func (s *NotifiersTestSuite) SetupSuite() {
 	s.IntegrationTestSuite.SetupSuite()
+}
+
+func (s *NotifiersTestSuite) TearDownSuite() {
+	s.IntegrationTestSuite.TearDownSuite()
+}
+
+func (s *NotifiersTestSuite) SetupTest() {
+	s.IntegrationTestSuite.SetupTest()
 
 	var err error
-	s.notifier, err = s.client.Notifiers.Create(s.suiteCtx, axiom.Notifier{
+	s.notifier, err = s.client.Notifiers.Create(s.ctx, axiom.Notifier{
 		Name: "Test Notifier",
 		Properties: axiom.NotifierProperties{
 			Email: &axiom.EmailConfig{
@@ -40,21 +47,21 @@ func (s *NotifiersTestSuite) SetupSuite() {
 	s.Require().NotNil(s.notifier)
 }
 
-func (s *NotifiersTestSuite) TearDownSuite() {
+func (s *NotifiersTestSuite) TearDownTest() {
 	// Teardown routines use their own context to avoid not being run at all
 	// when the suite gets cancelled or times out.
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), time.Second*15)
 	defer cancel()
 
 	err := s.client.Notifiers.Delete(ctx, s.notifier.ID)
 	s.NoError(err)
 
-	s.IntegrationTestSuite.TearDownSuite()
+	s.IntegrationTestSuite.TearDownTest()
 }
 
 func (s *NotifiersTestSuite) Test() {
 	// Let's update the notifier.
-	notifier, err := s.client.Notifiers.Update(s.suiteCtx, s.notifier.ID, axiom.Notifier{
+	notifier, err := s.client.Notifiers.Update(s.ctx, s.notifier.ID, axiom.Notifier{
 		Name: "Updated Test Notifier",
 		Properties: axiom.NotifierProperties{
 			Email: &axiom.EmailConfig{

--- a/axiom/users.go
+++ b/axiom/users.go
@@ -163,7 +163,7 @@ func (s *UsersService) Get(ctx context.Context, id string) (*User, error) {
 	return &res, nil
 }
 
-// Create will create and invite a user to the organisation
+// Create will create and invite a user to the organisation.
 func (s *UsersService) Create(ctx context.Context, req CreateUserRequest) (*User, error) {
 	ctx, span := s.client.trace(ctx, "Users.Create", trace.WithAttributes(
 		attribute.String("axiom.user_name", req.Name),

--- a/axiom/users.go
+++ b/axiom/users.go
@@ -150,7 +150,7 @@ func (s *UsersService) Get(ctx context.Context, id string) (*User, error) {
 	))
 	defer span.End()
 
-	path, err := url.JoinPath(s.basePath, "/", id)
+	path, err := url.JoinPath(s.basePath, id)
 	if err != nil {
 		return nil, spanError(span, err)
 	}
@@ -189,7 +189,7 @@ func (s *UsersService) Update(ctx context.Context, id string, req UpdateUserRequ
 		))
 	defer span.End()
 
-	path, err := url.JoinPath(s.basePath, "/", id)
+	path, err := url.JoinPath(s.basePath, id)
 	if err != nil {
 		return nil, spanError(span, err)
 	}
@@ -211,7 +211,7 @@ func (s *UsersService) UpdateUsersRole(ctx context.Context, id string, req Updat
 		))
 	defer span.End()
 
-	path, err := url.JoinPath(s.basePath, "/", id, "/role")
+	path, err := url.JoinPath(s.basePath, id, "role")
 	if err != nil {
 		return nil, spanError(span, err)
 	}
@@ -231,7 +231,7 @@ func (s *UsersService) Delete(ctx context.Context, id string) error {
 	))
 	defer span.End()
 
-	path, err := url.JoinPath(s.basePath, "/", id)
+	path, err := url.JoinPath(s.basePath, id)
 	if err != nil {
 		return spanError(span, err)
 	}


### PR DESCRIPTION
As part of reviewing #320 I discovered two quirks, mostly coming from copy&paste over the years:

1. `url.JoinPath` had some unnecessary params being passed in
2. The integration test suits had a couple of quirks regarding their usage