### PR TITLE
chore: code grooming

### DIFF
--- a/axiom/client.go
+++ b/axiom/client.go
@@ -69,7 +69,7 @@ func DefaultHTTPTransport() http.RoundTripper {
 			KeepAlive: time.Second * 30,
 		}).DialContext,
 		IdleConnTimeout:       time.Second * 90,
-		ResponseHeaderTimeout: time.Second * 10,
+		ResponseHeaderTimeout: time.Second * 30,
 		TLSHandshakeTimeout:   time.Second * 10,
 		ExpectContinueTimeout: time.Second * 1,
 		ForceAttemptHTTP2:     true,

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -10,14 +10,12 @@ import (
 	"mime"
 	"net"
 	"net/http"
-	"net/http/httptrace"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/klauspost/compress/gzhttp"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -215,7 +213,6 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body any) 
 		}
 	}
 
-	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
 	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* Drop `httptrace` instrumentation (to granular, users can still opt-in manually)
* Extend the response header timeout from `10s` to `30s`