### PR TITLE
Remove the pagerduty token field

### DIFF
--- a/axiom/notifiers.go
+++ b/axiom/notifiers.go
@@ -73,8 +73,6 @@ type OpsGenieConfig struct {
 type PagerDutyConfig struct {
 	// RoutingKey is the routing key to use for authentication.
 	RoutingKey string `json:"routingKey,omitempty"`
-	// Token is the token to use for authentication.
-	Token string `json:"token,omitempty"`
 }
 
 type SlackConfig struct {


### PR DESCRIPTION
The pagerduty token is not required for out pagerduty notifier.

We're removing the need for the token from the api