### PR TITLE
Idiomatic zerolog adapter readme

### DIFF
--- a/adapters/zerolog/README.md
+++ b/adapters/zerolog/README.md
@@ -21,7 +21,7 @@ function:
 
 ```go
 writer, err := adapter.New(
-    WithDatasetName("logs"),
+    adapter.SetDataset("logs"),
 )
 l.Logger = zerolog.New(io.MultiWriter(writer, os.Stderr)).With().Timestamp().Logger()
 ```

--- a/adapters/zerolog/README.md
+++ b/adapters/zerolog/README.md
@@ -23,7 +23,7 @@ function:
 writer, err := adapter.New(
     WithDatasetName("logs"),
 )
-l.Logger = zerolog.New(io.MultiWriter(writer, os.Stderr)).With().Str("env", os.Getenv("ENV")).Timestamp().Logger()
+l.Logger = zerolog.New(io.MultiWriter(writer, os.Stderr)).With().Timestamp().Logger()
 ```
 
 To configure the underlying client manually either pass in a client that was
@@ -43,7 +43,7 @@ writer, err := adapter.New()
 if err != nil {
     log.Fatal(err)
 }
-l.Logger = zerolog.New(io.MultiWriter(writer, os.Stderr)).With().Str("env", os.Getenv("ENV")).Timestamp().Logger()
+l.Logger = zerolog.New(io.MultiWriter(writer, os.Stderr)).With().Timestamp().Logger()
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
The readme in the zerolog adapter is not quite idiomatic. It does not [separate logs by environment](https://axiom.co/docs/reference/datasets#separate-by-environment). It uses a non-existing function `WithDatasetName` instead of `adapter.SetDataset`. This PR addresses these issues.