### PR TITLE
.github/workflows: replace deprecated 'axiom dataset info' with 'axiom query' to verify test

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Cleanup (On Test Failure)
         if: failure()
         run: |
-          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.10.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
+          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.14.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
           axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ matrix.go }}")).id' | xargs -r -n1 axiom dataset delete -f
 
   ci-pass:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -91,5 +91,5 @@ jobs:
       - name: Cleanup (On Test Failure)
         if: failure()
         run: |
-          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.10.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
+          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.14.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
           axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ matrix.go }}")).id' | xargs -r -n1 axiom dataset delete -f

--- a/.github/workflows/server_regression.yaml
+++ b/.github/workflows/server_regression.yaml
@@ -51,5 +51,5 @@ jobs:
       - name: Cleanup (On Test Failure)
         if: failure()
         run: |
-          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.10.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
+          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.14.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
           axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ matrix.go }}")).id' | xargs -r -n1 axiom dataset delete -f

--- a/.github/workflows/test_examples.yaml
+++ b/.github/workflows/test_examples.yaml
@@ -95,7 +95,7 @@ jobs:
           go-version-file: go.mod
       - name: Setup test dataset
         run: |
-          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.10.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
+          curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.14.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
           axiom dataset create -n=$AXIOM_DATASET -d="Axiom Go ${{ matrix.example }} example test"
       - name: Setup example
         if: matrix.setup

--- a/.github/workflows/test_examples.yaml
+++ b/.github/workflows/test_examples.yaml
@@ -46,24 +46,24 @@ jobs:
         include:
           - example: apex
             verify: |
-              axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . == 3 )'
+              axiom query -f=json "['$AXIOM_DATASET'] | count" | jq -e '. == 3'
           - example: ingestevent
             verify: |
-              axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . == 2 )'
+              axiom query -f=json "['$AXIOM_DATASET'] | count" | jq -e '. == 2'
           - example: ingestfile
             setup: |
-              echo '[{"timestamp":"1668773301","mood":"hyped","msg":"This is awesome!"}]' >> logs.json
+              echo '[{"timestamp":"'$(date +%s)'","mood":"hyped","msg":"This is awesome!"}]' >> logs.json
             verify: |
-              axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . == 1 )'
+              axiom query -f=json "['$AXIOM_DATASET'] | count" | jq -e '. == 1'
           - example: logrus
             verify: |
-              axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . == 3 )'
+              axiom query -f=json "['$AXIOM_DATASET'] | count" | jq -e '. == 3'
           - example: otelinstrument
             verify: |
-              axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . >= 1 )'
+              axiom query -f=json "['$AXIOM_DATASET'] | count" | jq -e '. >= 1'
           - example: oteltraces
             verify: |
-              axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . == 2 )'
+              axiom query -f=json "['$AXIOM_DATASET'] | count" | jq -e '. == 2'
           - example: query
             setup: |
               echo '[{"mood":"hyped","msg":"This is awesome!"}]' >> logs.json
@@ -76,13 +76,13 @@ jobs:
               sleep 5
           - example: slog
             verify: |
-              axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . == 3 )'
+              axiom query -f=json "['$AXIOM_DATASET'] | count" | jq -e '. == 3'
           - example: zap
             verify: |
-              axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . == 3 )'
+              axiom query -f=json "['$AXIOM_DATASET'] | count" | jq -e '. == 3'
           - example: zerolog
             verify: |
-              axiom dataset info $AXIOM_DATASET -f=json | jq -e 'any( .numEvents ; . == 3 )'
+              axiom query -f=json "['$AXIOM_DATASET'] | count" | jq -e '. == 3'
     env:
       AXIOM_URL: ${{ secrets.TESTING_STAGING_API_URL }}
       AXIOM_TOKEN: ${{ secrets.TESTING_STAGING_TOKEN }}

--- a/adapters/apex/apex_example_test.go
+++ b/adapters/apex/apex_example_test.go
@@ -18,6 +18,6 @@ func Example() {
 	log.SetHandler(handler)
 
 	log.WithField("mood", "hyped").Info("This is awesome!")
-	log.WithField("mood", "worried").Warn("This is no that awesome...")
+	log.WithField("mood", "worried").Warn("This is not that awesome...")
 	log.WithField("mood", "depressed").Error("This is rather bad.")
 }

--- a/adapters/apex/apex_integration_test.go
+++ b/adapters/apex/apex_integration_test.go
@@ -25,7 +25,7 @@ func Test(t *testing.T) {
 		log.SetHandler(handler)
 
 		log.WithField("mood", "hyped").Info("This is awesome!")
-		log.WithField("mood", "worried").Warn("This is no that awesome...")
+		log.WithField("mood", "worried").Warn("This is not that awesome...")
 		log.WithField("mood", "depressed").Error("This is rather bad.")
 	})
 }

--- a/adapters/logrus/logrus_example_test.go
+++ b/adapters/logrus/logrus_example_test.go
@@ -21,7 +21,7 @@ func Example() {
 	logger.AddHook(hook)
 
 	logger.WithField("mood", "hyped").Info("This is awesome!")
-	logger.WithField("mood", "worried").Warn("This is no that awesome...")
+	logger.WithField("mood", "worried").Warn("This is not that awesome...")
 	logger.WithField("mood", "depressed").Error("This is rather bad.")
 
 	logrus.Exit(0)

--- a/adapters/logrus/logrus_integration_test.go
+++ b/adapters/logrus/logrus_integration_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 		logger.AddHook(hook)
 
 		logger.WithField("mood", "hyped").Info("This is awesome!")
-		logger.WithField("mood", "worried").Warn("This is no that awesome...")
+		logger.WithField("mood", "worried").Warn("This is not that awesome...")
 		logger.WithField("mood", "depressed").Error("This is rather bad.")
 	})
 }

--- a/adapters/slog/slog_example_test.go
+++ b/adapters/slog/slog_example_test.go
@@ -19,6 +19,6 @@ func Example() {
 	logger := slog.New(handler)
 
 	logger.Info("This is awesome!", "mood", "hyped")
-	logger.With("mood", "worried").Warn("This is no that awesome...")
+	logger.With("mood", "worried").Warn("This is not that awesome...")
 	logger.Error("This is rather bad.", slog.String("mood", "depressed"))
 }

--- a/adapters/slog/slog_integration_test.go
+++ b/adapters/slog/slog_integration_test.go
@@ -25,7 +25,7 @@ func Test(t *testing.T) {
 		logger := slog.New(handler)
 
 		logger.Info("This is awesome!", slog.String("mood", "hyped"))
-		logger.Warn("This is no that awesome...", slog.String("mood", "worried"))
+		logger.Warn("This is not that awesome...", slog.String("mood", "worried"))
 		logger.Error("This is rather bad.", slog.String("mood", "depressed"))
 	})
 }

--- a/adapters/zap/zap_example_test.go
+++ b/adapters/zap/zap_example_test.go
@@ -24,6 +24,6 @@ func Example() {
 	}()
 
 	logger.Info("This is awesome!", zap.String("mood", "hyped"))
-	logger.Warn("This is no that awesome...", zap.String("mood", "worried"))
+	logger.Warn("This is not that awesome...", zap.String("mood", "worried"))
 	logger.Error("This is rather bad.", zap.String("mood", "depressed"))
 }

--- a/adapters/zap/zap_integration_test.go
+++ b/adapters/zap/zap_integration_test.go
@@ -28,7 +28,7 @@ func Test(t *testing.T) {
 		}()
 
 		logger.Info("This is awesome!", zap.String("mood", "hyped"))
-		logger.Warn("This is no that awesome...", zap.String("mood", "worried"))
+		logger.Warn("This is not that awesome...", zap.String("mood", "worried"))
 		logger.Error("This is rather bad.", zap.String("mood", "depressed"))
 	})
 }

--- a/adapters/zerolog/zerolog_example_test.go
+++ b/adapters/zerolog/zerolog_example_test.go
@@ -22,6 +22,6 @@ func Example() {
 	l.Logger = zerolog.New(io.MultiWriter(writer, os.Stderr)).With().Timestamp().Logger()
 
 	l.Logger.Info().Str("mood", "hyped").Msg("This is awesome!")
-	l.Logger.Warn().Str("mood", "worried").Msg("This is no that awesome...")
+	l.Logger.Warn().Str("mood", "worried").Msg("This is not that awesome...")
 	l.Logger.Error().Str("mood", "depressed").Msg("This is rather bad.")
 }

--- a/examples/apex/main.go
+++ b/examples/apex/main.go
@@ -27,6 +27,6 @@ func main() {
 
 	// 4. Log ⚡
 	log.WithField("mood", "hyped").Info("This is awesome!")
-	log.WithField("mood", "worried").Warn("This is no that awesome...")
+	log.WithField("mood", "worried").Warn("This is not that awesome...")
 	log.WithField("mood", "depressed").Error("This is rather bad.")
 }

--- a/examples/logrus/main.go
+++ b/examples/logrus/main.go
@@ -37,6 +37,6 @@ func main() {
 
 	// 6. Log ⚡
 	logger.WithField("mood", "hyped").Info("This is awesome!")
-	logger.WithField("mood", "worried").Warn("This is no that awesome...")
+	logger.WithField("mood", "worried").Warn("This is not that awesome...")
 	logger.WithField("mood", "depressed").Error("This is rather bad.")
 }

--- a/examples/slog/main.go
+++ b/examples/slog/main.go
@@ -31,6 +31,6 @@ func main() {
 
 	// 5. Log ⚡
 	logger.Info("This is awesome!", "mood", "hyped")
-	logger.With("mood", "worried").Warn("This is no that awesome...")
+	logger.With("mood", "worried").Warn("This is not that awesome...")
 	logger.Error("This is rather bad.", slog.String("mood", "depressed"))
 }

--- a/examples/zap/main.go
+++ b/examples/zap/main.go
@@ -33,6 +33,6 @@ func main() {
 
 	// 4. Log ⚡
 	logger.Info("This is awesome!", zap.String("mood", "hyped"))
-	logger.Warn("This is no that awesome...", zap.String("mood", "worried"))
+	logger.Warn("This is not that awesome...", zap.String("mood", "worried"))
 	logger.Error("This is rather bad.", zap.String("mood", "depressed"))
 }

--- a/examples/zerolog/main.go
+++ b/examples/zerolog/main.go
@@ -19,10 +19,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer writer.Close()
 
 	l.Logger = zerolog.New(io.MultiWriter(writer, os.Stderr)).With().Logger()
 
 	l.Logger.Info().Str("mood", "hyped").Msg("This is awesome!")
-	l.Logger.Warn().Str("mood", "worried").Msg("This is no that awesome...")
+	l.Logger.Warn().Str("mood", "worried").Msg("This is not that awesome...")
 	l.Logger.Error().Str("mood", "depressed").Msg("This is rather bad.")
 }


### PR DESCRIPTION
This PR does a couple of things to fix the partly broken `test_examples.yaml` workflow:

* Replaces the deprecated (and in more recent versions of CLI also deleted) `axiom dataset info` call with `axiom query`
* Uses a dynamic `timestamp` value for the `ingestfile` test
* Flushes the writer for the `zerolog` adapter example
* Bumps Axiom CLI to the most recent version