### PR TITLE
fix(datasets): permit canWrite property

### DIFF
--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -80,6 +80,8 @@ type Dataset struct {
 	CreatedBy string `json:"who"`
 	// CreatedAt is the time the dataset was created at.
 	CreatedAt time.Time `json:"created"`
+	// CanWrite sets whether writeable access is granted.
+	CanWrite bool `json:"canWrite"`
 }
 
 // DatasetCreateRequest is a request used to create a dataset.

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -362,6 +362,7 @@ func TestDatasetsService_List(t *testing.T) {
 			Description: "",
 			CreatedBy:   "f83e245a-afdc-47ad-a765-4addd1994321",
 			CreatedAt:   testhelper.MustTimeParse(t, time.RFC3339Nano, "2020-11-17T22:29:00.521238198Z"),
+			CanWrite:    true,
 		},
 	}
 
@@ -374,7 +375,8 @@ func TestDatasetsService_List(t *testing.T) {
 				"id": "test",
 				"name": "test",
 				"who": "f83e245a-afdc-47ad-a765-4addd1994321",
-				"created": "2020-11-17T22:29:00.521238198Z"
+				"created": "2020-11-17T22:29:00.521238198Z",
+				"canWrite": true
 			}
 		]`)
 		assert.NoError(t, err)


### PR DESCRIPTION
A new property was exposed via the v2 api "CanWrite", this PR gives axiom-go visibility on that.