### PR TITLE
feat: use more v2 endpoints

### DIFF
--- a/axiom/client_export_test.go
+++ b/axiom/client_export_test.go
@@ -32,7 +32,7 @@ func TestClient_Manual(t *testing.T) {
 		test: "test",
 	}
 
-	path, err := axiom.AddURLOptions("/v1/test", opts)
+	path, err := axiom.AddURLOptions("/v2/test", opts)
 	require.NoError(t, err)
 
 	req, err := client.NewRequest(t.Context(), http.MethodGet, path, nil)
@@ -66,7 +66,7 @@ func TestClient_Call(t *testing.T) {
 		test: "test",
 	}
 
-	path, err := axiom.AddURLOptions("/v1/test", opts)
+	path, err := axiom.AddURLOptions("/v2/test", opts)
 	require.NoError(t, err)
 
 	err = client.Call(t.Context(), http.MethodGet, path, nil, nil)

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -741,7 +741,7 @@ func (s *DatasetsService) Query(ctx context.Context, apl string, options ...quer
 			return nil, spanError(span, err)
 		}
 	} else {
-		// TODO(lukasmalkmus): Use 's.basePath' once ingest v2 is available.
+		// TODO(lukasmalkmus): Use 's.basePath' once query v2 is available.
 		path, err = url.JoinPath("/v1/datasets", "_apl")
 		if err != nil {
 			return nil, spanError(span, err)

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -1219,7 +1219,7 @@ func TestDatasetsService_QueryLegacy(t *testing.T) {
 	assert.Equal(t, expLegacyQueryRes, res)
 }
 
-func TestDatasetsService_QueryInvalid_InvalidSaveKind(t *testing.T) {
+func TestDatasetsService_QueryLegacyInvalid_InvalidSaveKind(t *testing.T) {
 	client := setup(t, "POST /v1/datasets/test/query", nil)
 
 	_, err := client.Datasets.QueryLegacy(t.Context(), "test", querylegacy.Query{}, querylegacy.Options{

--- a/axiom/orgs.go
+++ b/axiom/orgs.go
@@ -183,7 +183,7 @@ type wrappedOrganization struct {
 // OrganizationsService handles communication with the organization related
 // operations of the Axiom API.
 //
-// Axiom API Reference: /v1/orgs
+// Axiom API Reference: /v2/orgs
 type OrganizationsService service
 
 // List all available organizations.


### PR DESCRIPTION
Update test helpers and the orgs API reference comment to reflect the actual v2 base paths already in use. Keep ingest and query on their v1 endpoints until the server exposes v2 equivalents.