### PR TITLE
fix: ci

### DIFF
--- a/axiom/annotations_integration_test.go
+++ b/axiom/annotations_integration_test.go
@@ -59,14 +59,20 @@ func (s *AnnotationsTestSuite) TearDownTest() {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), time.Second*15)
 	defer cancel()
 
-	err := s.client.Datasets.Delete(ctx, s.datasetA.ID)
-	s.NoError(err)
+	if s.datasetA != nil {
+		err := s.client.Datasets.Delete(ctx, s.datasetA.ID)
+		s.NoError(err)
+	}
 
-	err = s.client.Datasets.Delete(ctx, s.datasetB.ID)
-	s.NoError(err)
+	if s.datasetB != nil {
+		err := s.client.Datasets.Delete(ctx, s.datasetB.ID)
+		s.NoError(err)
+	}
 
-	err = s.client.Annotations.Delete(ctx, s.annotation.ID)
-	s.NoError(err)
+	if s.annotation != nil {
+		err := s.client.Annotations.Delete(ctx, s.annotation.ID)
+		s.NoError(err)
+	}
 
 	s.IntegrationTestSuite.TearDownTest()
 }

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -82,6 +82,10 @@ type Dataset struct {
 	CreatedAt time.Time `json:"created"`
 	// CanWrite sets whether writeable access is granted.
 	CanWrite bool `json:"canWrite"`
+	// UseRetentionPeriod sets whether the dataset uses a retention period.
+	UseRetentionPeriod bool `json:"useRetentionPeriod"`
+	// RetentionDays is the number of days events are kept in the dataset.
+	RetentionDays int `json:"retentionDays"`
 }
 
 // DatasetCreateRequest is a request used to create a dataset.

--- a/axiom/datasets_integration_test.go
+++ b/axiom/datasets_integration_test.go
@@ -103,8 +103,10 @@ func (s *DatasetsTestSuite) TearDownTest() {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), time.Second*15)
 	defer cancel()
 
-	err := s.client.Datasets.Delete(ctx, s.dataset.ID)
-	s.NoError(err)
+	if s.dataset != nil {
+		err := s.client.Datasets.Delete(ctx, s.dataset.ID)
+		s.NoError(err)
+	}
 
 	s.IntegrationTestSuite.TearDownTest()
 }

--- a/axiom/error_integration_test.go
+++ b/axiom/error_integration_test.go
@@ -33,7 +33,7 @@ func (s *ErrorTestSuite) Test() {
 	// (unauthenticated).
 	_, err = s.client.Datasets.Get(s.ctx, invalidDatasetName)
 	s.Require().Error(err)
-	s.Require().ErrorIs(err, axiom.ErrUnauthorized)
+	s.Require().ErrorIs(err, axiom.ErrUnauthenticated)
 
 	// Restore valid credentials.
 	s.newClient()

--- a/axiom/monitors_integration_test.go
+++ b/axiom/monitors_integration_test.go
@@ -49,8 +49,10 @@ func (s *MonitorsTestSuite) TearDownSuite() {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.suiteCtx), time.Second*15)
 	defer cancel()
 
-	err := s.client.Datasets.Delete(ctx, s.datasetID)
-	s.NoError(err)
+	if s.datasetID != "" {
+		err := s.client.Datasets.Delete(ctx, s.datasetID)
+		s.NoError(err)
+	}
 
 	s.IntegrationTestSuite.TearDownSuite()
 }
@@ -87,8 +89,10 @@ func (s *MonitorsTestSuite) TearDownTest() {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), time.Second*15)
 	defer cancel()
 
-	err := s.client.Monitors.Delete(ctx, s.monitor.ID)
-	s.NoError(err)
+	if s.monitor != nil {
+		err := s.client.Monitors.Delete(ctx, s.monitor.ID)
+		s.NoError(err)
+	}
 
 	s.IntegrationTestSuite.TearDownTest()
 }

--- a/axiom/notifiers_integration_test.go
+++ b/axiom/notifiers_integration_test.go
@@ -53,8 +53,10 @@ func (s *NotifiersTestSuite) TearDownTest() {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), time.Second*15)
 	defer cancel()
 
-	err := s.client.Notifiers.Delete(ctx, s.notifier.ID)
-	s.NoError(err)
+	if s.notifier != nil {
+		err := s.client.Notifiers.Delete(ctx, s.notifier.ID)
+		s.NoError(err)
+	}
 
 	s.IntegrationTestSuite.TearDownTest()
 }

--- a/axiom/tokens_integration_test.go
+++ b/axiom/tokens_integration_test.go
@@ -45,8 +45,10 @@ func (s *TokensTestSuite) TearDownTest() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 	defer cancel()
 
-	err := s.client.Tokens.Delete(ctx, s.apiToken.ID)
-	s.NoError(err)
+	if s.apiToken != nil {
+		err := s.client.Tokens.Delete(ctx, s.apiToken.ID)
+		s.NoError(err)
+	}
 
 	s.IntegrationTestSuite.TearDownTest()
 }

--- a/axiom/vfields_integration_test.go
+++ b/axiom/vfields_integration_test.go
@@ -57,11 +57,15 @@ func (s *VirtualFieldsTestSuite) TearDownTest() {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(s.ctx), time.Second*15)
 	defer cancel()
 
-	err := s.client.VirtualFields.Delete(ctx, s.vfield.ID)
-	s.NoError(err)
+	if s.vfield != nil {
+		err := s.client.VirtualFields.Delete(ctx, s.vfield.ID)
+		s.NoError(err)
+	}
 
-	err = s.client.Datasets.Delete(ctx, s.dataset)
-	s.NoError(err)
+	if s.dataset != "" {
+		err := s.client.Datasets.Delete(ctx, s.dataset)
+		s.NoError(err)
+	}
 
 	s.IntegrationTestSuite.TearDownTest()
 }


### PR DESCRIPTION
1. Adds new dataset fields.
2. Make sure to protect against nil pointer dereferences when tearing down a failed test.