### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/axiom/client_options.go
+++ b/axiom/client_options.go
@@ -93,8 +93,11 @@ func SetNoRetry() Option {
 	}
 }
 
-// SetNoTracing prevents the [Client] from acquiring a tracer from the global
-// tracer provider, even if one is configured.
+// SetNoTracing prevents the [Client] from acquiring a tracer. It doesn't
+// affect the default HTTP client transport used by the [Client], which uses
+// [otelhttp.NewTransport] to create a new trace for each outgoing HTTP request.
+// To prevent that behavior, users must provide their own HTTP client via
+// [SetClient].
 func SetNoTracing() Option {
 	return func(c *Client) error {
 		c.tracer = noop.Tracer{}


### PR DESCRIPTION
Properly document that the underlying HTTP client used by default is equipped with a transport that is OTel enabled, even is `SetNoTracing` is provided. Users are expected to set their own client if they wish to prevent this.