### PR TITLE
Added a logger package example

### DIFF
--- a/examples/package/log/logger.go
+++ b/examples/package/log/logger.go
@@ -1,0 +1,65 @@
+package log
+
+import (
+	"sync"
+
+	adapter "github.com/axiomhq/axiom-go/adapters/logrus"
+	"github.com/sirupsen/logrus"
+)
+
+var globalLoggers = make(map[string]*logrus.Entry)
+var globalLoggerMu sync.RWMutex
+var baseLogger *logrus.Logger
+
+const serviceKey = "service"
+
+func init() {
+	hook, err := adapter.New()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	logrus.RegisterExitHandler(hook.Close)
+
+	baseLogger = logrus.New()
+	baseLogger.AddHook(hook)
+}
+
+func GetLogger(serviceName string) *logrus.Entry {
+	l := getCachedLogger(serviceName)
+	if l != nil {
+		return l
+	}
+	return createCachedLogger(serviceName)
+}
+
+func createCachedLogger(serviceName string) *logrus.Entry {
+	globalLoggerMu.Lock()
+	defer globalLoggerMu.Unlock()
+
+	if l := globalLoggers[serviceName]; l != nil {
+		return l
+	}
+
+	logger := baseLogger.WithField(serviceKey, serviceName)
+	globalLoggers[serviceName] = logger
+	return logger
+}
+
+func getCachedLogger(serviceName string) *logrus.Entry {
+	globalLoggerMu.RLock()
+	defer globalLoggerMu.RUnlock()
+
+	return globalLoggers[serviceName]
+}
+
+func Flush() {
+	for _, hooks := range baseLogger.Hooks {
+		for _, hook := range hooks {
+			if axiomHook, ok := hook.(*adapter.Hook); ok {
+				axiomHook.Close()
+			}
+		}
+	}
+	logrus.Exit(0)
+}

--- a/examples/package/main.go
+++ b/examples/package/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/axiomhq/axiom-go/examples/package/log"
+	"github.com/axiomhq/axiom-go/examples/package/service_a"
+)
+
+var logger = log.GetLogger("my-app")
+
+func main() {
+	logger.Info("started")
+
+	service_a.Run()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	logger.Info("finished")
+	log.Flush()
+	os.Exit(0)
+}

--- a/examples/package/service_a/main.go
+++ b/examples/package/service_a/main.go
@@ -1,0 +1,9 @@
+package service_a
+
+import "github.com/axiomhq/axiom-go/examples/package/log"
+
+var logger = log.GetLogger("service-a")
+
+func Run() {
+	logger.Info("running")
+}


### PR DESCRIPTION
I've created a logger package which is similar to what we do internally regarding the architecture. It basically creates "sub" loggers from the main base logger and flushes the logs to axiom on exit. 

Confirmed here:
![image](https://github.com/user-attachments/assets/1a3cc746-3d39-4dfd-9aa9-c989199543e7)

