### PR TITLE
Add source on slog adapter

### DIFF
--- a/adapters/slog/slog.go
+++ b/adapters/slog/slog.go
@@ -70,7 +70,7 @@ func SetLevel(level slog.Leveler) Option {
 	}
 }
 
-// SetAddSource specifies whether to add the source of the log message to The
+// SetAddSource specifies whether to add the source of the log message to The Event.
 func SetAddSource(addSource bool) Option {
 	return func(h *Handler) error {
 		h.addSource = addSource

--- a/adapters/slog/slog.go
+++ b/adapters/slog/slog.go
@@ -71,9 +71,9 @@ func SetLevel(level slog.Leveler) Option {
 }
 
 // SetAddSource specifies whether to add the source of the log message to the event.
-func SetAddSource(addSource bool) Option {
+func SetAddSource() Option {
 	return func(h *Handler) error {
-		h.addSource = addSource
+		h.addSource = true
 		return nil
 	}
 }

--- a/adapters/slog/slog.go
+++ b/adapters/slog/slog.go
@@ -70,7 +70,7 @@ func SetLevel(level slog.Leveler) Option {
 	}
 }
 
-// SetAddSource specifies whether to add the source of the log message to The Event.
+// SetAddSource specifies whether to add the source of the log message to the event.
 func SetAddSource(addSource bool) Option {
 	return func(h *Handler) error {
 		h.addSource = addSource

--- a/adapters/slog/slog_test.go
+++ b/adapters/slog/slog_test.go
@@ -200,7 +200,7 @@ func setupWithSource(t *testing.T) func(dataset string, client *axiom.Client) (*
 		handler, err := New(
 			SetClient(client),
 			SetDataset(dataset),
-			SetAddSource(true),
+			SetAddSource(),
 		)
 		require.NoError(t, err)
 		t.Cleanup(handler.Close)

--- a/adapters/slog/slog_test.go
+++ b/adapters/slog/slog_test.go
@@ -74,8 +74,9 @@ func TestHandler(t *testing.T) {
 }
 
 func TestHandler_Source(t *testing.T) {
-	_, file, _, _ := runtime.Caller(0)
-	sourceStr := fmt.Sprintf(`{"file":"%s", "function":"github.com/axiomhq/axiom-go/adapters/slog.TestHandler_Source", "line":105}`, file)
+	_, file, line, _ := runtime.Caller(0)
+	line += 29 // Account for the lines until the log line.
+	sourceStr := fmt.Sprintf(`{"file":"%s", "function":"github.com/axiomhq/axiom-go/adapters/slog.TestHandler_Source", "line":%d}`, file, line)
 
 	exp := fmt.Sprintf(`{"_time":"%s","level":"INFO","key":"value","msg":"my message", "source":%s}`,
 		time.Now().Format(time.RFC3339Nano), sourceStr)


### PR DESCRIPTION
Added the "AddSource" option to the slog adapter to better replicate the behavior of the default handler.

Since the slog.Record.source() method is private, I had to replicate its functionality.

I also didn't want to mess with the original "setup" method on the test so i created my own "setupWithSource"