### PR TITLE
adapters: always loop until explicitly closed

### DIFF
--- a/adapters/zerolog/zerolog.go
+++ b/adapters/zerolog/zerolog.go
@@ -169,15 +169,12 @@ func (w *Writer) runBackgroundJob() {
 	var (
 		counter = 0
 		buffer  = &bytes.Buffer{}
-		t       = time.NewTicker(flushInterval)
 		encoder = axiom.ZstdEncoder()
 	)
-	defer t.Stop()
 
 	flush := func() error {
 		defer func() {
 			counter = 0
-			t.Reset(flushInterval)
 			buffer.Reset()
 		}()
 
@@ -244,7 +241,7 @@ func (w *Writer) runBackgroundJob() {
 					logger.Printf("failed to ingest events: %s\n", err)
 				}
 			}
-		case <-t.C:
+		case <-time.After(flushInterval):
 			if err := flush(); err != nil {
 				logger.Printf("failed to ingest events: %s\n", err)
 			}

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -512,8 +512,8 @@ func (s *DatasetsService) IngestChannel(ctx context.Context, id string, events <
 			return fmt.Errorf("failed to ingest events: %w", err)
 		}
 		ingestStatus.Add(res)
-		t.Reset(flushInterval) // Reset the ticker.
 		batch = batch[:0]      // Clear the batch.
+		t.Reset(flushInterval) // Reset the ticker.
 
 		return nil
 	}
@@ -521,7 +521,6 @@ func (s *DatasetsService) IngestChannel(ctx context.Context, id string, events <
 	for {
 		select {
 		case <-ctx.Done():
-
 			return &ingestStatus, spanError(span, context.Cause(ctx))
 		case event, ok := <-events:
 			if !ok {


### PR DESCRIPTION
This makes sure our adapters never stop logging, even if they continuously hit errors.

Food for thought: Maybe this design means we should add error callback handlers so consumers have a chance to act on errors.