### PR TITLE
chore: use error message as value on slog adapter

### DIFF
--- a/adapters/slog/slog.go
+++ b/adapters/slog/slog.go
@@ -282,7 +282,12 @@ func addAttrToEvent(event axiom.Event, attr slog.Attr) {
 			event[attr.Key] = group
 		}
 	} else {
-		event[attr.Key] = v.Any()
+		a := v.Any()
+		if err, ok := a.(error); ok {
+			//If the value is an error, we want to use the error message.
+			a = err.Error()
+		}
+		event[attr.Key] = a
 	}
 }
 


### PR DESCRIPTION
This PR adds special handling for error values in the slog adapter to ensure their error messages are used.

Previously, when sending an error as an Any value, it would be converted into an empty map[string]interface{}. This caused the value to be ignored by Axiom.

To address this, I added a special case to handle values that are instances of error, similar to how the std [JSONHandler](https://github.com/golang/go/blob/master/src/log/slog/json_handler.go) handles them.

i get that this somewhat breaks the flow of the code and the user can easily resolve this by explicitly writing:

```go
slog.String("error",err.Error())
```

instead of

```go
slog.Any("Error",err)
```

But in my option this gets annoying to do pretty quick

There is an argument to be made that the entire `addAttrToEvent` function should be rewritten IF the intention is to replicate the behavior of the std JSONHandler.

Witch in my understanding kinda is because a JSON in what axiom is getting,but i can be wrong and that's ok

That said, this PR focuses on addressing the specific issue of handling error values, and a broader rewrite could be considered as a separate improvement.