### PR TITLE
Axiom/Datasets/MapFields: Adjust for new API responses

### DIFF
--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -306,7 +306,7 @@ func (s *DatasetsService) ListMapFields(ctx context.Context, id string) (MapFiel
 }
 
 // Create a new map-field with the given name on the dataset identified by the given id.
-func (s *DatasetsService) CreateMapField(ctx context.Context, id string, name string) (*string, error) {
+func (s *DatasetsService) CreateMapField(ctx context.Context, id string, name string) (string, error) {
 	ctx, span := s.client.trace(ctx, "Datasets.CreateMapField", trace.WithAttributes(
 		attribute.String("axiom.dataset_id", id),
 		attribute.String("axiom.param.name", name),
@@ -319,15 +319,15 @@ func (s *DatasetsService) CreateMapField(ctx context.Context, id string, name st
 
 	path, err := url.JoinPath(s.basePath, id, "mapfields")
 	if err != nil {
-		return nil, spanError(span, err)
+		return "", spanError(span, err)
 	}
 
 	var res mapField
 	if err := s.client.Call(ctx, http.MethodPost, path, req, &res); err != nil {
-		return nil, spanError(span, err)
+		return "", spanError(span, err)
 	}
 
-	return &res.Name, nil
+	return res.Name, nil
 }
 
 // Update map-fields on the dataset identified by the given id.

--- a/axiom/datasets_integration_test.go
+++ b/axiom/datasets_integration_test.go
@@ -496,7 +496,7 @@ func (s *DatasetsTestSuite) TestMapFields() {
 		res, err := s.client.Datasets.CreateMapField(s.ctx, s.dataset.ID, "foo")
 		s.Require().NoError(err)
 		s.Require().NotNil(res)
-		s.Equal("foo", *res)
+		s.Equal("foo", res)
 
 		// ...and verify it's listed on the dataset.
 		dataset, err := s.client.Datasets.Get(s.ctx, s.dataset.ID)
@@ -646,7 +646,7 @@ func (s *DatasetsTestSuite) TestIngestWithMapFields() {
 	res, err := s.client.Datasets.CreateMapField(s.ctx, s.dataset.ID, "foo")
 	s.Require().NoError(err)
 	s.Require().NotNil(res)
-	s.Equal("foo", *res)
+	s.Equal("foo", res)
 
 	// Ingest some data containing an object.
 	ingestObjectDataFn(s, ingestDataMapFields1)

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -560,7 +560,7 @@ func TestDatasetsService_CreateMapField(t *testing.T) {
 	res, err := client.Datasets.CreateMapField(context.Background(), "test", "field1")
 	require.NoError(t, err)
 
-	assert.Equal(t, "field1", *res)
+	assert.Equal(t, "field1", res)
 }
 
 func TestDatasetsService_UpdateMapFields(t *testing.T) {


### PR DESCRIPTION
This PR also includes the changes from https://github.com/axiomhq/axiom-go/pull/380 to fix the flakey regression/acceptance tests.

This needs an updated version of the Axiom-v2-API to be deployed first, before the changes are to be released
(this is also the reason for the failing integration tests atm).

Dependency of https://github.com/axiomhq/terraform-provider-axiom/pull/70
Supersedes https://github.com/axiomhq/axiom-go/pull/380