### PR TITLE
Update README to mention AXIOM_URL

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -39,8 +39,6 @@ To quickstart, export the environment variables below.
 #### Optional environment variables
 
 - `AXIOM_URL`: [Region](https://axiom.co/docs/reference/regions#axiom-api-reference) to use. Defaults to US.
-- `AXIOM_ORG_ID`: Organization identifier of the organization to (when using a
-  personal token).
 
 ## Package usage
 


### PR DESCRIPTION
It's not clear in the docs that this variable needs to be set to switch region, so I'm adding it explicitly to avoid 403/permission errors. 
