### PR TITLE
adapters/zerolog: fix counter increment before level check

### DIFF
--- a/adapters/zerolog/zerolog.go
+++ b/adapters/zerolog/zerolog.go
@@ -214,8 +214,6 @@ func (w *Writer) runBackgroundJob() {
 				continue
 			}
 
-			counter++
-
 			lvlStr, err := jsonparser.GetUnsafeString(data, zerolog.LevelFieldName)
 			if err != nil {
 				logger.Printf("failed to retrieve level field name from data: %s\n", err)
@@ -231,6 +229,8 @@ func (w *Writer) runBackgroundJob() {
 			if _, enabled := w.levels[lvl]; !enabled {
 				continue
 			}
+
+			counter++
 
 			data, _ = jsonparser.Set(data, loggerName, "logger")
 


### PR DESCRIPTION
Fixes a bug where the counter was incremented before checking if the log level was enabled, causing premature batch flushes.