### PR TITLE
ci: bump Go version matrix to 1.24/1.25

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.23"
           - "1.24"
+          - "1.25"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -38,8 +38,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.23"
           - "1.24"
+          - "1.25"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -65,8 +65,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - "1.23"
           - "1.24"
+          - "1.25"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -98,8 +98,8 @@ jobs:
       fail-fast: true
       matrix:
         go:
-          - "1.23"
           - "1.24"
+          - "1.25"
         environment:
           - development
           - staging

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.23"
           - "1.24"
+          - "1.25"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -35,8 +35,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.23"
           - "1.24"
+          - "1.25"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -64,8 +64,8 @@ jobs:
       fail-fast: true
       matrix:
         go:
-          - "1.23"
           - "1.24"
+          - "1.25"
         environment:
           - development
           - staging


### PR DESCRIPTION
## Summary

Updates CI workflows to test against Go 1.24 and 1.25, dropping support for Go 1.23.

Go 1.25 was released in August 2025 and has been stable for several months. Per our policy of supporting the last two Go versions, this updates the CI matrix accordingly.

**Changes:**
- `.github/workflows/pr.yaml`: Update Go matrix from 1.23/1.24 to 1.24/1.25
- `.github/workflows/push.yaml`: Update Go matrix from 1.23/1.24 to 1.24/1.25

**Note:** `go.mod` remains at Go 1.24.0 as the minimum supported version. The `test_examples.yaml` workflow already uses `go-version-file: go.mod` so it will automatically use the go.mod version.

## Test plan

- [x] CI passes with Go 1.24
- [x] CI passes with Go 1.25