### PR TITLE
adapters/zerolog: use variadic signature for SetClientOptions

### DIFF
--- a/adapters/zerolog/zerolog.go
+++ b/adapters/zerolog/zerolog.go
@@ -98,10 +98,12 @@ func SetDataset(dataset string) Option {
 	}
 }
 
-// SetClientOptions configures the axiom client options.
-func SetClientOptions(clientOptions []axiom.Option) Option {
+// SetClientOptions specifies the Axiom client options to pass to
+// [axiom.NewClient] which is only called if no [axiom.Client] was specified by
+// the [SetClient] option.
+func SetClientOptions(options ...axiom.Option) Option {
 	return func(cfg *Writer) error {
-		cfg.clientOptions = clientOptions
+		cfg.clientOptions = options
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

Change `SetClientOptions` from `[]axiom.Option` slice to `...axiom.Option` variadic to match all other adapters (zap, slog, logrus, apex).

This improves API consistency and ergonomics:

```go
// Before (zerolog only)
adapter.SetClientOptions([]axiom.Option{axiom.SetEdge("...")})

// After (consistent with other adapters)
adapter.SetClientOptions(axiom.SetEdge("..."))
```

## Changes

- `adapters/zerolog/zerolog.go` - Changed `SetClientOptions(clientOptions []axiom.Option)` to `SetClientOptions(options ...axiom.Option)`
- Updated doc comment to match other adapters

## Breaking Change

This is technically a breaking change for any code that explicitly passes a slice:

```go
// This will no longer compile:
adapter.SetClientOptions([]axiom.Option{...})

// Must change to:
adapter.SetClientOptions(axiom.SetEdge("..."))
// Or if you have a slice:
adapter.SetClientOptions(opts...)
```

However, this aligns zerolog with all other adapters and the idiomatic Go pattern.

## Test Plan

- [x] `go build ./adapters/zerolog/...` passes
- [x] `go test ./adapters/zerolog/...` passes