### PR TITLE
axiom: set Proxy in DefaultHTTPTransport

### DIFF
--- a/axiom/client.go
+++ b/axiom/client.go
@@ -66,6 +66,7 @@ func DefaultHTTPClient() *http.Client {
 // [DefaultHTTPClient].
 func DefaultHTTPTransport() http.RoundTripper {
 	return otelhttp.NewTransport(gzhttp.Transport(&http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   time.Second * 30,
 			KeepAlive: time.Second * 30,


### PR DESCRIPTION
The custom `http.Transport` in `DefaultHTTPTransport` omits the `Proxy` field, which defaults to `nil`. Unlike `http.DefaultTransport`, which sets `Proxy` to `http.ProxyFromEnvironment`, this means the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables are silently ignored.

This breaks any consumer running behind an HTTP proxy, such as the `axiom-lambda-extension` running in a Lambda with an egress proxy.