### PR TITLE
axiom: bump OTel semconv to v1.39.0

### DIFF
--- a/axiom/client.go
+++ b/axiom/client.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/axiomhq/axiom-go/axiom/ingest"

--- a/axiom/otel/trace.go
+++ b/axiom/otel/trace.go
@@ -13,7 +13,7 @@ import (
 
 	// Keep in sync with
 	// https://github.com/open-telemetry/opentelemetry-go/blob/main/sdk/resource/builtin.go#L16.
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 
 	"github.com/axiomhq/axiom-go/internal/version"
 )


### PR DESCRIPTION
Aligns semconv import path with what OTel SDK v1.40.0 uses internally in `sdk/resource/builtin.go`.