### PR TITLE
axiom: add zstd compression level support

### DIFF
--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/klauspost/compress/zstd"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -538,7 +539,8 @@ func (s *DatasetsService) IngestEvents(ctx context.Context, id string, events []
 	getBody := func() (io.ReadCloser, error) {
 		pr, pw := io.Pipe()
 
-		zsw := zstdPool.Get()
+		pool := zstdPools[zstdPoolIndex(zstd.SpeedDefault)]
+		zsw := pool.Get()
 		zsw.Reset(pw)
 
 		go func() {
@@ -557,7 +559,7 @@ func (s *DatasetsService) IngestEvents(ctx context.Context, id string, events []
 					encErr = closeErr
 				}
 			} else {
-				zstdPool.Put(zsw)
+				pool.Put(zsw)
 			}
 			_ = pw.CloseWithError(encErr)
 		}()

--- a/axiom/encoder.go
+++ b/axiom/encoder.go
@@ -13,8 +13,9 @@ import (
 // functionality and returns that enhanced reader. The content type of the
 // encoded content must obviously be accepted by the server.
 //
-// The built-in encoders returned by [GzipEncoder], [GzipEncoderWithLevel] and
-// [ZstdEncoder] pool compression writers internally to amortize allocation
+// The built-in encoders returned by [GzipEncoder], [GzipEncoderWithLevel],
+// [ZstdEncoder] and [ZstdEncoderWithLevel] pool compression writers internally
+// to amortize allocation
 // costs. Use [NewPooledEncoder] to create a pooled encoder for a custom
 // compression writer.
 //
@@ -51,14 +52,27 @@ func (p *encoderPool[T]) Put(v T) {
 	p.pool.Put(v)
 }
 
-// zstdPool is the package-level pool for zstd writers (SpeedDefault).
-var zstdPool = newEncoderPool(func() *zstd.Encoder {
-	w, err := zstd.NewWriter(nil)
-	if err != nil {
-		panic("zstd: failed to create writer: " + err.Error())
+// zstdPools holds per-level pools for zstd writers. The array is indexed by
+// zstdPoolIndex, covering all valid zstd levels from SpeedFastest (1) through
+// SpeedBestCompression (4).
+var zstdPools [zstd.SpeedBestCompression - zstd.SpeedFastest + 1]*encoderPool[*zstd.Encoder]
+
+func init() {
+	for level := zstd.SpeedFastest; level <= zstd.SpeedBestCompression; level++ {
+		l := level
+		zstdPools[zstdPoolIndex(l)] = newEncoderPool(func() *zstd.Encoder {
+			w, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(l))
+			if err != nil {
+				panic("zstd: failed to create writer: " + err.Error())
+			}
+			return w
+		})
 	}
-	return w
-})
+}
+
+func zstdPoolIndex(level zstd.EncoderLevel) int {
+	return int(level - zstd.SpeedFastest)
+}
 
 // gzipPools holds per-level pools for gzip writers. The array is indexed by
 // gzipPoolIndex, covering all valid gzip levels from HuffmanOnly (-2) through
@@ -132,8 +146,22 @@ func GzipEncoderWithLevel(level int) ContentEncoder {
 }
 
 // ZstdEncoder returns a content encoder that zstd compresses the data it reads
-// from the provided reader. Writers are pooled internally to avoid the ~4 MB
+// from the provided reader. The compression level defaults to
+// [zstd.SpeedDefault]. Writers are pooled internally to avoid the ~4 MB
 // allocation cost per [zstd.NewWriter] call.
 func ZstdEncoder() ContentEncoder {
-	return pooledContentEncoder(zstdPool)
+	return ZstdEncoderWithLevel(zstd.SpeedDefault)
+}
+
+// ZstdEncoderWithLevel returns a content encoder that zstd compresses data
+// using the specified compression level. Writers are pooled internally per
+// compression level.
+func ZstdEncoderWithLevel(level zstd.EncoderLevel) ContentEncoder {
+	idx := zstdPoolIndex(level)
+	if idx < 0 || idx >= len(zstdPools) || zstdPools[idx] == nil {
+		return func(_ io.Reader) (io.Reader, error) {
+			return nil, fmt.Errorf("unsupported zstd compression level: %d", level)
+		}
+	}
+	return pooledContentEncoder(zstdPools[idx])
 }

--- a/axiom/encoder_test.go
+++ b/axiom/encoder_test.go
@@ -51,6 +51,37 @@ func TestZstdEncoder(t *testing.T) {
 	assert.Equal(t, exp, string(act))
 }
 
+func TestZstdEncoderWithLevel(t *testing.T) {
+	exp := "Some fox jumps over a fence."
+
+	levels := []zstd.EncoderLevel{
+		zstd.SpeedFastest,
+		zstd.SpeedDefault,
+		zstd.SpeedBetterCompression,
+		zstd.SpeedBestCompression,
+	}
+	for _, level := range levels {
+		t.Run(level.String(), func(t *testing.T) {
+			r, err := ZstdEncoderWithLevel(level)(strings.NewReader(exp))
+			require.NoError(t, err)
+
+			zsr, err := zstd.NewReader(r)
+			require.NoError(t, err)
+			defer zsr.Close()
+
+			act, err := io.ReadAll(zsr)
+			require.NoError(t, err)
+
+			assert.Equal(t, exp, string(act))
+		})
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := ZstdEncoderWithLevel(zstd.EncoderLevel(42))(strings.NewReader(exp))
+		assert.ErrorContains(t, err, "unsupported zstd compression level")
+	})
+}
+
 func BenchmarkZstdEncoder_Allocs(b *testing.B) {
 	b.ReportAllocs()
 	data := testdata.Load(b)


### PR DESCRIPTION
## Summary

- Add `ZstdEncoderWithLevel` to allow configuring zstd compression levels, mirroring the existing `GzipEncoderWithLevel` API
- Replace single `zstdPool` with per-level pools since `zstd.WithEncoderLevel` cannot be changed on `Reset`
- `ZstdEncoder()` keeps defaulting to `SpeedDefault` (no behavioral change)

Follows up on #413 review feedback from @tsenart.