### PR TITLE
lint: fix golangci-lint warnings for gosec, goconst, and revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -52,6 +52,14 @@ linters:
       - linters:
           - staticcheck
         text: "SA1019:.*QueryLegacy is deprecated"
+      - linters:
+          - revive
+        path: adapters/slog/
+        text: "var-naming: avoid package names that conflict"
+      - linters:
+          - revive
+        path: internal/version/
+        text: "var-naming: avoid package names that conflict"
     paths:
       - .git
       - .github

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -264,7 +264,7 @@ func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 
 		err = backoff.Retry(func() error {
 			var httpResp *http.Response
-			//nolint:bodyclose // The response body is closed later down below.
+			//nolint:bodyclose,gosec // The response body is closed later down below. G704: URL is from trusted configuration.
 			httpResp, err = c.httpClient.Do(req)
 			switch {
 			case errors.Is(err, context.Canceled):
@@ -292,7 +292,7 @@ func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 		}, bck)
 	} else {
 		var httpResp *http.Response
-		//nolint:bodyclose // The response body is closed later down below.
+		//nolint:bodyclose,gosec // The response body is closed later down below. G704: URL is from trusted configuration.
 		if httpResp, err = c.httpClient.Do(req); err != nil {
 			return nil, err
 		}

--- a/axiom/encoder_test.go
+++ b/axiom/encoder_test.go
@@ -15,8 +15,10 @@ import (
 	"github.com/axiomhq/axiom-go/internal/test/testdata"
 )
 
+const testEncoderInput = "Some fox jumps over a fence."
+
 func TestGzipEncoder(t *testing.T) {
-	exp := "Some fox jumps over a fence."
+	exp := testEncoderInput
 
 	r, err := GzipEncoder()(strings.NewReader(exp))
 	require.NoError(t, err)
@@ -36,7 +38,7 @@ func TestGzipEncoder(t *testing.T) {
 }
 
 func TestZstdEncoder(t *testing.T) {
-	exp := "Some fox jumps over a fence."
+	exp := testEncoderInput
 
 	r, err := ZstdEncoder()(strings.NewReader(exp))
 	require.NoError(t, err)
@@ -52,7 +54,7 @@ func TestZstdEncoder(t *testing.T) {
 }
 
 func TestZstdEncoderWithLevel(t *testing.T) {
-	exp := "Some fox jumps over a fence."
+	exp := testEncoderInput
 
 	levels := []zstd.EncoderLevel{
 		zstd.SpeedFastest,

--- a/axiom/notifiers.go
+++ b/axiom/notifiers.go
@@ -65,7 +65,7 @@ type EmailConfig struct {
 
 type OpsGenieConfig struct {
 	// APIKey is the API key to use for authentication.
-	APIKey string `json:"apiKey,omitempty"`
+	APIKey string `json:"apiKey,omitempty"` //nolint:gosec // G117: Legitimate API configuration field.
 	// IsEU indicates whether the OpsGenie instance is in the EU.
 	IsEU bool `json:"isEU,omitempty"`
 }

--- a/examples/ingestevent/main.go
+++ b/examples/ingestevent/main.go
@@ -41,6 +41,6 @@ func main() {
 
 	// 3. Make sure everything went smoothly.
 	for _, fail := range res.Failures {
-		log.Print(fail.Error)
+		log.Print(fail.Error) //nolint:gosec // G706: Error from trusted Axiom API response.
 	}
 }

--- a/examples/ingestfile/main.go
+++ b/examples/ingestfile/main.go
@@ -52,6 +52,6 @@ func main() {
 
 	// 5. Make sure everything went smoothly.
 	for _, fail := range res.Failures {
-		log.Print(fail.Error)
+		log.Print(fail.Error) //nolint:gosec // G706: Error from trusted Axiom API response.
 	}
 }

--- a/examples/ingesthackernews/main.go
+++ b/examples/ingesthackernews/main.go
@@ -99,7 +99,7 @@ func main() {
 	// Note: If you ever make it here, you have ingested all of Hacknews into
 	// Axiom. Congratulations... I guess?! 🤔
 	for _, fail := range res.Failures {
-		log.Print(fail.Error)
+		log.Print(fail.Error) //nolint:gosec // G706: Error from trusted Axiom API response.
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extract repeated test string to a constant to fix goconst warning in encoder tests
- Add `//nolint:gosec` directives for G704 (SSRF false positives on `httpClient.Do`), G117 (APIKey field name), and G706 (log injection in examples)
- Add exclusion rules for revive `var-naming` on `adapters/slog` and `internal/version` packages that intentionally share names with stdlib packages