### PR TITLE
axiom: remove stale nolint directive

### DIFF
--- a/axiom/notifiers.go
+++ b/axiom/notifiers.go
@@ -65,7 +65,7 @@ type EmailConfig struct {
 
 type OpsGenieConfig struct {
 	// APIKey is the API key to use for authentication.
-	APIKey string `json:"apiKey,omitempty"` //nolint:gosec // G117: Legitimate API configuration field.
+	APIKey string `json:"apiKey,omitempty"`
 	// IsEU indicates whether the OpsGenie instance is in the EU.
 	IsEU bool `json:"isEU,omitempty"`
 }


### PR DESCRIPTION
Remove unused `//nolint:gosec` directive on `OpsGenieConfig.APIKey` that causes a persistent `nolintlint` CI failure on main.

The `gosec` linter no longer flags this field, making the directive stale.