### PR TITLE
json+tabular support

### DIFF
--- a/axiom/client.go
+++ b/axiom/client.go
@@ -41,9 +41,10 @@ const (
 
 	headerTraceID = "X-Axiom-Trace-Id"
 
-	defaultMediaType = "application/octet-stream"
-	mediaTypeJSON    = "application/json"
-	mediaTypeNDJSON  = "application/x-ndjson"
+	defaultMediaType     = "application/octet-stream"
+	mediaTypeJSON        = "application/json"
+	mediaTypeJSONTabular = "application/json+tabular"
+	mediaTypeNDJSON      = "application/x-ndjson"
 
 	otelTracerName = "github.com/axiomhq/axiom-go/axiom"
 )
@@ -248,6 +249,10 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body any) 
 	return req, nil
 }
 
+func isJSONContentType(ct string) bool {
+	return ct == mediaTypeJSON || ct == mediaTypeJSONTabular
+}
+
 // Do sends an API request and returns the API response. The response body is
 // JSON decoded or directly written to v, depending on v being an [io.Writer] or
 // not.
@@ -327,7 +332,7 @@ func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 		}
 
 		// Handle a generic HTTP error if the response is not JSON formatted.
-		if ct, _, _ := mime.ParseMediaType(resp.Header.Get(headerContentType)); ct != mediaTypeJSON {
+		if ct, _, _ := mime.ParseMediaType(resp.Header.Get(headerContentType)); !isJSONContentType(ct) {
 			return resp, httpErr
 		}
 
@@ -373,7 +378,7 @@ func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 			return resp, err
 		}
 
-		if ct, _, _ := mime.ParseMediaType(resp.Header.Get(headerContentType)); ct != mediaTypeJSON {
+		if ct, _, _ := mime.ParseMediaType(resp.Header.Get(headerContentType)); !isJSONContentType(ct) {
 			return resp, fmt.Errorf("cannot decode response with unsupported content type %q", ct)
 		}
 

--- a/axiom/client_test.go
+++ b/axiom/client_test.go
@@ -471,6 +471,30 @@ func TestClient_Do_ioWriter(t *testing.T) {
 	assert.Equal(t, content, buf.String())
 }
 
+func TestClient_Do_jsonTabularContentType(t *testing.T) {
+	hf := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+
+		w.Header().Set("Content-Type", mediaTypeJSONTabular)
+		_, _ = fmt.Fprint(w, `{"A":"a"}`)
+	}
+
+	client := setup(t, "GET /", hf)
+
+	type foo struct {
+		A string
+	}
+
+	req, err := client.NewRequest(t.Context(), http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	var body foo
+	_, err = client.Do(req, &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, foo{"a"}, body)
+}
+
 func TestClient_Do_unsupportedContentType(t *testing.T) {
 	hf := func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", mediaTypeJSON+"bad")


### PR DESCRIPTION
The current version of the Grafana plugin is breaking on this when querying metrics.

Example error on the Grafana plugin:
```json
{"results":{"A":{"error":"axiom error: cannot decode response with unsupported content type \"application/json+tabular\"","errorSource":"plugin","status":400,"frames":[]}}}
```

Building a custom version of the Grafana plugin with this patch solves this issue in a local Grafana environment.