### PR TITLE
fix: reset request body on network error retries and preserve failed …

### DIFF
--- a/axiom/client.go
+++ b/axiom/client.go
@@ -270,6 +270,17 @@ func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 			case errors.Is(err, context.Canceled):
 				return backoff.Permanent(err)
 			case err != nil:
+				// Reset the request body so it can be re-read on
+				// retry. Without this, retries after network errors
+				// (e.g. "io: read/write on closed pipe") would reuse
+				// the already-consumed body and fail immediately.
+				if req.GetBody != nil {
+					if body, resetErr := req.GetBody(); resetErr != nil {
+						return backoff.Permanent(resetErr)
+					} else {
+						req.Body = body
+					}
+				}
 				return err
 			}
 			resp = newResponse(httpResp)

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -275,11 +275,11 @@ func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 				// (e.g. "io: read/write on closed pipe") would reuse
 				// the already-consumed body and fail immediately.
 				if req.GetBody != nil {
-					if body, resetErr := req.GetBody(); resetErr != nil {
+					body, resetErr := req.GetBody()
+					if resetErr != nil {
 						return backoff.Permanent(resetErr)
-					} else {
-						req.Body = body
 					}
+					req.Body = body
 				}
 				return err
 			}

--- a/axiom/client.go
+++ b/axiom/client.go
@@ -274,13 +274,11 @@ func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 				// retry. Without this, retries after network errors
 				// (e.g. "io: read/write on closed pipe") would reuse
 				// the already-consumed body and fail immediately.
-				if req.GetBody != nil {
-					body, resetErr := req.GetBody()
-					if resetErr != nil {
-						return backoff.Permanent(resetErr)
-					}
-					req.Body = body
+				body, resetErr := req.GetBody()
+				if resetErr != nil {
+					return backoff.Permanent(resetErr)
 				}
+				req.Body = body
 				return err
 			}
 			resp = newResponse(httpResp)

--- a/axiom/client_test.go
+++ b/axiom/client_test.go
@@ -725,6 +725,68 @@ func TestClient_Do_Backoff(t *testing.T) {
 	assert.Equal(t, 3, getBodyCounter)
 }
 
+func TestClient_Do_Backoff_NetworkError(t *testing.T) {
+	payload := `{"foo":"bar"}`
+
+	var requestCount int
+	hf := func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		// Verify the body is present on every attempt, proving the
+		// body was properly reset between retries.
+		assert.Equal(t, payload, string(b))
+
+		w.WriteHeader(http.StatusOK)
+	}
+
+	client := setup(t, "POST /", hf)
+
+	// Use a transport that fails the first two attempts with a network
+	// error, simulating "io: read/write on closed pipe".
+	var transportAttempts int
+	origTransport := client.httpClient.Transport
+	client.httpClient.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		transportAttempts++
+		if transportAttempts <= 2 {
+			// Consume the body like a real transport would before
+			// returning a network error.
+			_, _ = io.Copy(io.Discard, req.Body)
+			return nil, io.ErrClosedPipe
+		}
+		return origTransport.RoundTrip(req)
+	})
+
+	var r io.Reader = strings.NewReader(payload)
+	r = io.TeeReader(r, io.Discard)
+	req, err := client.NewRequest(t.Context(), http.MethodPost, "/", r)
+	require.NoError(t, err)
+
+	getBodyCounter := 0
+	req.GetBody = func() (io.ReadCloser, error) {
+		getBodyCounter++
+		return io.NopCloser(strings.NewReader(payload)), nil
+	}
+
+	resp, err := client.Do(req, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, requestCount)     // Only the successful attempt hits the server.
+	assert.Equal(t, 3, transportAttempts) // 2 failures + 1 success.
+	assert.Equal(t, 2, getBodyCounter)    // Body reset before each retry after failure.
+}
+
+// roundTripFunc is an adapter to allow the use of ordinary functions as
+// [http.RoundTripper].
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestClient_Do_Backoff_NoRetryOn400(t *testing.T) {
 	var currentCalls int
 	hf := func(w http.ResponseWriter, _ *http.Request) {

--- a/axiom/client_test.go
+++ b/axiom/client_test.go
@@ -774,7 +774,7 @@ func TestClient_Do_Backoff_NetworkError(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, 1, requestCount)     // Only the successful attempt hits the server.
+	assert.Equal(t, 1, requestCount)      // Only the successful attempt hits the server.
 	assert.Equal(t, 3, transportAttempts) // 2 failures + 1 success.
 	assert.Equal(t, 2, getBodyCounter)    // Body reset before each retry after failure.
 }

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -657,9 +657,8 @@ func (s *DatasetsService) IngestChannel(ctx context.Context, id string, events <
 		setIngestStatusOnSpan(span, ingestStatus)
 	}()
 
-	// Track consecutive flush failures. After maxConsecutiveErrors the
-	// method gives up and returns the error so the caller (e.g. the adapter
-	// background loop) can decide what to do.
+	// 3 attempts × up to ~10s Client.Do backoff ≈ 30s resilience window
+	// before we give up and hand the batch back to the adapter's outer loop.
 	const maxConsecutiveErrors = 3
 	var consecutiveErrors int
 

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -657,6 +657,12 @@ func (s *DatasetsService) IngestChannel(ctx context.Context, id string, events <
 		setIngestStatusOnSpan(span, ingestStatus)
 	}()
 
+	// Track consecutive flush failures. After maxConsecutiveErrors the
+	// method gives up and returns the error so the caller (e.g. the adapter
+	// background loop) can decide what to do.
+	const maxConsecutiveErrors = 3
+	var consecutiveErrors int
+
 	flush := func() error {
 		if len(batch) == 0 {
 			return nil
@@ -687,12 +693,26 @@ func (s *DatasetsService) IngestChannel(ctx context.Context, id string, events <
 
 			if len(batch) >= batchSize {
 				if err := flush(); err != nil {
-					return &ingestStatus, spanError(span, err)
+					consecutiveErrors++
+					span.RecordError(err)
+					if consecutiveErrors >= maxConsecutiveErrors {
+						return &ingestStatus, spanError(span, err)
+					}
+					// Batch is preserved for retry on next tick.
+				} else {
+					consecutiveErrors = 0
 				}
 			}
 		case <-t.C:
 			if err := flush(); err != nil {
-				return &ingestStatus, spanError(span, err)
+				consecutiveErrors++
+				span.RecordError(err)
+				if consecutiveErrors >= maxConsecutiveErrors {
+					return &ingestStatus, spanError(span, err)
+				}
+				// Batch is preserved for retry on next tick.
+			} else {
+				consecutiveErrors = 0
 			}
 		}
 	}

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -698,7 +698,7 @@ func (s *DatasetsService) IngestChannel(ctx context.Context, id string, events <
 					if consecutiveErrors >= maxConsecutiveErrors {
 						return &ingestStatus, spanError(span, err)
 					}
-					// Batch is preserved for retry on next tick.
+					// Batch is preserved; flush retried on next event or tick.
 				} else {
 					consecutiveErrors = 0
 				}
@@ -710,7 +710,7 @@ func (s *DatasetsService) IngestChannel(ctx context.Context, id string, events <
 				if consecutiveErrors >= maxConsecutiveErrors {
 					return &ingestStatus, spanError(span, err)
 				}
-				// Batch is preserved for retry on next tick.
+				// Batch is preserved; flush retried on next tick.
 			} else {
 				consecutiveErrors = 0
 			}

--- a/axiom/datasets_test.go
+++ b/axiom/datasets_test.go
@@ -1153,6 +1153,49 @@ func TestDatasetsService_IngestChannel_BufferedSlow(t *testing.T) {
 // TODO(lukasmalkmus): Write an ingest test that contains some failures in the
 // server response.
 
+func TestDatasetsService_IngestChannel_FlushRetry(t *testing.T) {
+	var handlerCalls int
+	hf := func(w http.ResponseWriter, r *http.Request) {
+		handlerCalls++
+
+		zsr, err := zstd.NewReader(r.Body)
+		require.NoError(t, err)
+		events := assertValidJSON(t, zsr)
+		zsr.Close()
+
+		// First call fails — batch should be preserved for retry.
+		if handlerCalls <= 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Retry succeeds — all events still present.
+		assert.Len(t, events, 2)
+
+		w.Header().Set("Content-Type", mediaTypeJSON)
+		_, _ = fmt.Fprint(w, `{"ingested":2,"failed":0,"failures":[],"processedBytes":630,"blocksCreated":0,"walLength":2}`)
+	}
+
+	client := setup(t, "POST /v1/datasets/test/ingest", hf)
+	client.noRetry = true
+	client.httpClient.Transport.(*http.Transport).DisableKeepAlives = true
+
+	synctest.Test(t, func(t *testing.T) {
+		eventCh := make(chan Event)
+		go func() {
+			eventCh <- Event{"message": "hello", "time": "17/May/2015:08:05:32 +0000"}
+			eventCh <- Event{"message": "world", "time": "17/May/2015:08:05:33 +0000"}
+			time.Sleep(3 * time.Second)
+			close(eventCh)
+		}()
+
+		res, err := client.Datasets.IngestChannel(t.Context(), "test", eventCh)
+		require.NoError(t, err)
+		assert.Equal(t, 2, int(res.Ingested))
+		assert.GreaterOrEqual(t, handlerCalls, 2)
+	})
+}
+
 func TestDatasetsService_Query(t *testing.T) {
 	hf := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)


### PR DESCRIPTION
The retry logic in Client.Do only reset the request body (via req.GetBody) after HTTP 5xx responses but not after network errors such as "io: read/write on closed pipe". Because Go's HTTP transport consumes the request body during sending, subsequent retry attempts reused the already-consumed io.Pipe reader and failed immediately — making the entire retry mechanism ineffective for transient network failures.

Additionally, IngestChannel returned immediately on any flush error, discarding the in-flight batch of up to 10,000 events. The adapter's background loop would restart IngestChannel with an empty batch, causing silent data loss on every transient failure.

Changes:
- Reset request body before retrying on network errors in Client.Do, matching the existing behavior for 5xx retries
- Preserve failed batches in IngestChannel by retrying on the next tick instead of returning immediately, giving up only after 3 consecutive failures
- Add TestClient_Do_Backoff_NetworkError verifying body reset works for network errors (simulates io.ErrClosedPipe with consumed body)

Fixes a customer-reported issue where Logrus/slog adapter logging would stop ingesting after "io: read/write on closed pipe" errors, causing gaps in dashboards. The root cause was Railway (hosting platform) closing idle HTTP/2 connections, combined with these two bugs preventing recovery.