### PR TITLE
.github/workflows/pr.yaml: scope integration test concurrency per ref

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -87,11 +87,13 @@ jobs:
     # upstream repository.
     if: github.event.pull_request.head.repo.full_name == github.repository
     # HINT(lukasmalkmus): Make sure the job is only ever run once per
-    # environment, across all active jobs and workflows. Errors on the
-    # development environment will not cancel the matrix jobs on the staging
-    # environment (and thus not affect the overall workflow status).
+    # environment per ref. Including the ref scopes the lock to the current
+    # PR/push so concurrent PRs don't cancel each other's matrix jobs.
+    # Errors on the development environment will not cancel the matrix jobs
+    # on the staging environment (and thus not affect the overall workflow
+    # status).
     concurrency:
-      group: ${{ matrix.environment }}
+      group: ${{ matrix.environment }}-${{ github.ref }}
       cancel-in-progress: false
     continue-on-error: ${{ matrix.environment == 'development' }}
     strategy:


### PR DESCRIPTION
The integration test job's concurrency group was just `${{ matrix.environment }}`, so the lock applied across every active PR. With dependabot bumping six dependencies in parallel, the matrix entries from one PR would cancel the queued entries from another, leaving the workflow stuck cycling through `cancelled` matrix jobs until reruns finally drained the queue.

Scoping the group to `${{ matrix.environment }}-${{ github.ref }}` preserves the original intent (1.25 and 1.26 matrix entries for the same env serialize within a single PR/push) but lets concurrent PRs run their integration tests in parallel.

The hint comment is updated to match.
