### PR TITLE
axiom: add integration test verifying header event labels are applied

### DIFF
--- a/axiom/datasets_integration_test.go
+++ b/axiom/datasets_integration_test.go
@@ -371,6 +371,70 @@ func (s *DatasetsTestSuite) Test() {
 	s.Require().NoError(err)
 }
 
+// TestIngestEventLabelsApplied verifies that header-supplied event labels (set
+// via [ingest.SetEventLabel] and shipped as the `X-Axiom-Event-Labels` header
+// by the SDK) actually land on ingested events and are queryable. A failure
+// here means labels are not being applied server-side, independent of any
+// `ProcessedBytes` accounting changes.
+func (s *DatasetsTestSuite) TestIngestEventLabelsApplied() {
+	now := time.Now().Truncate(time.Second)
+	events := []axiom.Event{
+		{
+			ingest.TimestampField: now,
+			"test_id":             "label-roundtrip",
+		},
+	}
+
+	ingestStatus, err := s.client.Datasets.IngestEvents(s.ctx, s.dataset.ID, events,
+		ingest.SetEventLabel("region", "eu-west-1"),
+	)
+	s.Require().NoError(err)
+	s.Require().NotNil(ingestStatus)
+	s.EqualValues(1, ingestStatus.Ingested)
+	s.Zero(ingestStatus.Failed)
+
+	apl := fmt.Sprintf("['%s'] | where test_id == 'label-roundtrip'", s.dataset.ID)
+	startTime := now.Add(-time.Minute)
+	endTime := now.Add(time.Minute)
+
+	var queryResult *query.Result
+	s.Require().Eventually(func() bool {
+		queryResult, err = s.client.Datasets.Query(s.ctx, apl,
+			query.SetStartTime(startTime),
+			query.SetEndTime(endTime),
+		)
+		return err == nil && queryResult != nil && queryResult.Status.RowsMatched == 1
+	}, 15*time.Second, 500*time.Millisecond, "ingested event did not become queryable in time")
+
+	s.Require().Len(queryResult.Tables, 1)
+	table := queryResult.Tables[0]
+
+	regionIdx := -1
+	for i, f := range table.Fields {
+		if f.Name == "region" {
+			regionIdx = i
+			break
+		}
+	}
+	s.Require().GreaterOrEqualf(regionIdx, 0,
+		"the 'region' label field is missing from the queried event — header-supplied event labels were not applied; fields present: %v",
+		fieldNames(table.Fields),
+	)
+
+	s.Require().Len(table.Columns, len(table.Fields))
+	s.Require().Len(table.Columns[regionIdx], 1)
+	s.Equal("eu-west-1", table.Columns[regionIdx][0],
+		"the 'region' label is present but its value does not match the header-supplied label")
+}
+
+func fieldNames(fields []query.Field) []string {
+	names := make([]string, len(fields))
+	for i, f := range fields {
+		names[i] = f.Name
+	}
+	return names
+}
+
 func (s *DatasetsTestSuite) TestCursor() {
 	// Let's ingest some data.
 	now := time.Now().Truncate(time.Second)


### PR DESCRIPTION
Adds a focused integration test (`TestDatasetsTestSuite/TestIngestEventLabelsApplied`) that ingests an event with a header-supplied label via `ingest.SetEventLabel`, then queries the dataset and asserts both that the `region` label field is present on the returned event and that its value matches what the SDK shipped in the `X-Axiom-Event-Labels` header.

## Context

The existing `TestDatasetsTestSuite/Test` and `TestDatasetsTestSuite/TestIngestWithMapFields` fail deterministically on `main` (see nightly run [25706497889](https://github.com/axiomhq/axiom-go/actions/runs/25706497889)) at the assertion `s.EqualValues(ingested.Len()+22, ingestStatus.ProcessedBytes)`. The 22 bytes correspond to the JSON-marshaled `X-Axiom-Event-Labels` header. The backend now returns `ProcessedBytes == ingested.Len()` exactly, so those header bytes are no longer counted in the byte accounting.

From the failure alone it was unclear whether the regression was purely an accounting change in `ProcessedBytes` or whether labels stopped being applied to events entirely. This test isolates the labeling question from the accounting question.

## Result

The test passes locally against staging on `main`'s tip, confirming that **labels still land on events** and **only the `ProcessedBytes` accounting changed**. Pushing as a draft so CI runs the same verification against both staging and development deployments across the Go matrix, and so the test stays in-tree as regression coverage going forward.

Follow-up (not in this PR): update the existing `Test`/`TestIngestWithMapFields` assertions to no longer expect `ProcessedBytes` to include label bytes (or revert the server change, depending on intent).
