### PR TITLE
axiom: add UpdatedAt to Dataset, Monitor and Notifier

### DIFF
--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -86,6 +86,8 @@ type Dataset struct {
 	CreatedBy string `json:"who"`
 	// CreatedAt is the time the dataset was created at.
 	CreatedAt time.Time `json:"created"`
+	// UpdatedAt is the time the dataset was last updated at.
+	UpdatedAt time.Time `json:"updatedAt"`
 	// CanWrite sets whether writeable access is granted.
 	CanWrite bool `json:"canWrite"`
 	// UseRetentionPeriod sets whether the dataset uses a retention period.

--- a/axiom/monitors.go
+++ b/axiom/monitors.go
@@ -119,6 +119,8 @@ type Monitor struct {
 	CreatedAt time.Time `json:"createdAt"`
 	// CreatedBy is the ID of the user who created the monitor.
 	CreatedBy string `json:"createdBy"`
+	// UpdatedAt is the time when the monitor was last updated.
+	UpdatedAt time.Time `json:"updatedAt"`
 	// Name is the name of the monitor.
 	Name string `json:"name"`
 	// Type sets the type of monitor. Defaults to [Threshold]

--- a/axiom/notifiers.go
+++ b/axiom/notifiers.go
@@ -23,6 +23,8 @@ type Notifier struct {
 	CreatedAt time.Time `json:"createdAt"`
 	// CreatedBy is the id of the user who created the notifier.
 	CreatedBy string `json:"createdBy"`
+	// UpdatedAt is the time when the notifier was last updated.
+	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 type NotifierProperties struct {


### PR DESCRIPTION
The v2 API now returns an `updatedAt` timestamp on dataset, monitor and notifier responses. The integration suite runs with strict JSON decoding, so the new field was rejected with `json: unknown field "updatedAt"`, failing every suite that creates a dataset or notifier in setup.

This adds the matching `UpdatedAt time.Time` field to the three structs, mirroring the existing `CreatedAt`, so the SDK models the field instead of choking on it. Regular SDK users are unaffected (strict decoding is a test-only option); this realigns the typed models with the API and exposes the timestamp.

Dashboards also gained `updatedAt` but are consumed as raw JSON here, so no change is needed there.

## Testing

`go test ./axiom/...` passes. The change is field-only (no new logic); the load-bearing coverage is the strict-decoding integration suite, which exercises these create/get round-trips against a live deployment and now decodes the `updatedAt` field instead of erroring.
