### PR TITLE
axiom: poll instead of sleep in edge integration tests

### DIFF
--- a/axiom/edge_integration_test.go
+++ b/axiom/edge_integration_test.go
@@ -162,21 +162,23 @@ func (s *EdgeTestSuite) TestEdgeQuery() {
 	s.Require().NotNil(ingestStatus)
 	s.EqualValues(2, ingestStatus.Ingested)
 
-	// Wait a moment for data to be queryable
-	time.Sleep(time.Second * 2)
-
-	now := time.Now().Truncate(time.Second)
-	startTime := now.Add(-time.Minute)
-	endTime := now.Add(time.Minute)
-
-	// Query via edge endpoint
 	apl := fmt.Sprintf("['%s']", s.dataset.ID)
-	queryResult, err := s.edgeClient.Datasets.Query(s.ctx, apl,
-		query.SetStartTime(startTime),
-		query.SetEndTime(endTime),
-	)
-	s.Require().NoError(err)
-	s.Require().NotNil(queryResult)
+	var queryResult *query.Result
+	s.Require().Eventually(func() bool {
+		now := time.Now().Truncate(time.Second)
+		res, err := s.edgeClient.Datasets.Query(s.ctx, apl,
+			query.SetStartTime(now.Add(-5*time.Minute)),
+			query.SetEndTime(now.Add(time.Minute)),
+		)
+		if err != nil || res == nil {
+			return false
+		}
+		if res.Status.RowsExamined < 2 || res.Status.RowsMatched < 2 {
+			return false
+		}
+		queryResult = res
+		return true
+	}, 30*time.Second, time.Second, "ingested events did not become queryable via edge")
 
 	s.NotZero(queryResult.Status.ElapsedTime)
 	s.GreaterOrEqual(queryResult.Status.RowsExamined, uint64(2))
@@ -205,21 +207,23 @@ func (s *EdgeTestSuite) TestEdgeIngestAndQueryRoundTrip() {
 	s.Require().NotNil(ingestStatus)
 	s.EqualValues(2, ingestStatus.Ingested)
 
-	// Wait for data to be queryable
-	time.Sleep(time.Second * 2)
-
-	now := time.Now().Truncate(time.Second)
-	startTime := now.Add(-time.Minute)
-	endTime := now.Add(time.Minute)
-
-	// Query for specific test data via edge
 	apl := fmt.Sprintf("['%s'] | where test_id startswith 'edge-roundtrip'", s.dataset.ID)
-	queryResult, err := s.edgeClient.Datasets.Query(s.ctx, apl,
-		query.SetStartTime(startTime),
-		query.SetEndTime(endTime),
-	)
-	s.Require().NoError(err)
-	s.Require().NotNil(queryResult)
+	var queryResult *query.Result
+	s.Require().Eventually(func() bool {
+		now := time.Now().Truncate(time.Second)
+		res, err := s.edgeClient.Datasets.Query(s.ctx, apl,
+			query.SetStartTime(now.Add(-5*time.Minute)),
+			query.SetEndTime(now.Add(time.Minute)),
+		)
+		if err != nil || res == nil {
+			return false
+		}
+		if res.Status.RowsMatched < 2 {
+			return false
+		}
+		queryResult = res
+		return true
+	}, 30*time.Second, time.Second, "ingested events did not become queryable via edge")
 
 	s.EqualValues(2, queryResult.Status.RowsMatched)
 }


### PR DESCRIPTION
`TestEdgeQuery` and `TestEdgeIngestAndQueryRoundTrip` ingested via the edge endpoint, slept a fixed 2 seconds, then queried once. Edge ingest becomes queryable asynchronously, so on a busy or slower deployment the single query fired before the data (and its schema) had propagated, producing intermittent `RowsExamined/RowsMatched=0` and a transient `API error 400: invalid field "test_id"` (the planner rejecting a field the dataset schema didn't know yet).

Both tests now poll with `require.Eventually` (30s timeout, 1s tick), re-running the query until the expected rows appear and treating a transient query error as "not ready yet" rather than a failure. The existing assertions run on the captured result afterwards, and the query time window is widened to cover the longer poll.

I audited every `time.Sleep` in the test suite: these two edge tests were the only ones waiting on real remote propagation. The rest are deliberate timing constructs (virtual-clock advancement inside `testing/synctest`, and giving a span a duration), so they are left untouched.

## Testing

Test-only change, no production code touched. `go build ./...`, `go vet`, and `golangci-lint` (including testifylint) are clean. The polling condition returns a plain bool with no assertions inside, so a failure in the retried goroutine can't escape testifylint's go-require rule. The fix targets flakiness, so the real validation is the integration suite no longer racing on edge propagation; the assertions themselves (row counts) are unchanged from before.
