### PR TITLE
Fix Missing edgeDeploymentUrl field and name search field

### DIFF
--- a/axiom/dashboards_integration_test.go
+++ b/axiom/dashboards_integration_test.go
@@ -183,7 +183,7 @@ func (s *DashboardsTestSuite) TestAllChartTypes() {
 		{"id": "sectionheader-1", "datasetId": s.dataset.ID, "type": "SectionHeader", "name": "Section Header", "query": baseQuery},
 		{"id": "note-1", "type": "Note", "text": "Integration note"},
 		{"id": "monitorlist-1", "type": "MonitorList", "name": "Monitor List", "selectedMonitors": []string{s.monitor.ID}, "columns": map[string]any{"status": true, "history": false, "dataset": false, "type": false, "notifiers": false}},
-		{"id": "smartfilter-1", "type": "SmartFilter", "name": "Filter Bar", "filters": []map[string]any{{"type": "search", "id": "sf-search"}}},
+		{"id": "smartfilter-1", "type": "SmartFilter", "name": "Filter Bar", "filters": []map[string]any{{"type": "search", "id": "sf-search", "name": "Search"}}},
 		{"id": "spacer-1", "type": "Spacer", "name": "Spacer"},
 		{"id": "placeholder-1", "type": "Placeholder"},
 	}

--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -99,6 +99,9 @@ type Dataset struct {
 	// EdgeDeployment is the edge deployment where the dataset is stored
 	// (e.g., "cloud.eu-central-1.aws").
 	EdgeDeployment string `json:"edgeDeployment,omitempty"`
+	// EdgeDeploymentURL is the URL of the edge deployment where the dataset is
+	// stored.
+	EdgeDeploymentURL string `json:"edgeDeploymentUrl,omitempty"`
 }
 
 // DatasetCreateRequest is a request used to create a dataset.


### PR DESCRIPTION
The shared integration suite runs against a live Axiom deployment with strict JSON decoding, so it started failing on every open PR (including the dependabot bumps) once the API drifted. This has two independent causes, both fixed here.

First, the API now returns an `edgeDeploymentUrl` field on datasets. With `DisallowUnknownFields` this broke decoding for every suite that creates or reads a dataset (datasets, edge, dashboards, virtual fields, annotations, monitors) with `json: unknown field "edgeDeploymentUrl"`. Added the matching `EdgeDeploymentURL` field to the `Dataset` struct.

Second, `TestAllChartTypes` built a SmartFilter search filter without a `name`, which the v2 dashboards schema requires, so the create was rejected with `dashboard validation failed at [charts 11 filters 0]: Invalid input`. Added the missing `name`. I verified against the dashboards zod validator that this was the only validation error in the payload and that it now passes.

Out of scope: the edge `TestEdgeQuery` timeout ("ingested events did not become queryable via edge") is a pre-existing eventual-consistency flake, not related to these changes.