### PR TITLE
axiom: reduce flakiness in dataset and edge integration tests

### DIFF
--- a/axiom/datasets_integration_test.go
+++ b/axiom/datasets_integration_test.go
@@ -656,18 +656,32 @@ func (s *DatasetsTestSuite) TestIngestWithMapFields() {
 	// Ingest some more data.
 	ingestObjectDataFn(s, ingestDataMapFields2)
 
-	now := time.Now().Truncate(time.Second)
-	startTime := now.Add(-time.Minute)
-	endTime := now.Add(time.Minute)
-
-	// Run a simple APL query...
+	// Run a simple APL query. Ingestion is eventually consistent, so poll until
+	// both rows and their full column schema (including the second event's
+	// flattened fields) have become queryable before asserting on the shape.
 	apl := fmt.Sprintf("['%s']", s.dataset.ID)
-	queryResult, err := s.client.Datasets.Query(s.ctx, apl,
-		query.SetStartTime(startTime),
-		query.SetEndTime(endTime),
-	)
-	s.Require().NoError(err)
-	s.Require().NotNil(queryResult)
+	var queryResult *query.Result
+	s.Require().Eventually(func() bool {
+		now := time.Now().Truncate(time.Second)
+		res, err := s.client.Datasets.Query(s.ctx, apl,
+			query.SetStartTime(now.Add(-5*time.Minute)),
+			query.SetEndTime(now.Add(time.Minute)),
+		)
+		if err != nil || res == nil {
+			return false
+		}
+		if res.Status.RowsExamined != 2 || res.Status.RowsMatched != 2 {
+			return false
+		}
+		if len(res.Tables) != 1 {
+			return false
+		}
+		if len(res.Tables[0].Fields) != 3+numExtraFields || len(res.Tables[0].Columns) != 3+numExtraColumns {
+			return false
+		}
+		queryResult = res
+		return true
+	}, 30*time.Second, time.Second, "ingested map field events did not become fully queryable")
 
 	s.NotZero(queryResult.Status.ElapsedTime)
 	s.EqualValues(2, queryResult.Status.RowsExamined)

--- a/axiom/edge_integration_test.go
+++ b/axiom/edge_integration_test.go
@@ -64,11 +64,9 @@ func (s *EdgeTestSuite) SetupSuite() {
 func (s *EdgeTestSuite) SetupTest() {
 	s.IntegrationTestSuite.SetupTest()
 
-	// Create test dataset using the main client (not edge - dataset creation isn't supported on edge).
-	// The name is unique per test so a failed teardown-delete (e.g. a transient
-	// API error) can't cascade into "entity exists" failures for later tests.
+	// Create test dataset using the main client (not edge - dataset creation isn't supported on edge)
 	req := axiom.DatasetCreateRequest{
-		Name:        fmt.Sprintf("test-axiom-go-edge-%s-%d", datasetSuffix, time.Now().UnixNano()),
+		Name:        "test-axiom-go-edge-" + datasetSuffix,
 		Description: "This is a test dataset for edge integration tests.",
 	}
 

--- a/axiom/edge_integration_test.go
+++ b/axiom/edge_integration_test.go
@@ -64,9 +64,11 @@ func (s *EdgeTestSuite) SetupSuite() {
 func (s *EdgeTestSuite) SetupTest() {
 	s.IntegrationTestSuite.SetupTest()
 
-	// Create test dataset using the main client (not edge - dataset creation isn't supported on edge)
+	// Create test dataset using the main client (not edge - dataset creation isn't supported on edge).
+	// The name is unique per test so a failed teardown-delete (e.g. a transient
+	// API error) can't cascade into "entity exists" failures for later tests.
 	req := axiom.DatasetCreateRequest{
-		Name:        "test-axiom-go-edge-" + datasetSuffix,
+		Name:        fmt.Sprintf("test-axiom-go-edge-%s-%d", datasetSuffix, time.Now().UnixNano()),
 		Description: "This is a test dataset for edge integration tests.",
 	}
 
@@ -178,7 +180,7 @@ func (s *EdgeTestSuite) TestEdgeQuery() {
 		}
 		queryResult = res
 		return true
-	}, 30*time.Second, time.Second, "ingested events did not become queryable via edge")
+	}, 60*time.Second, time.Second, "ingested events did not become queryable via edge")
 
 	s.NotZero(queryResult.Status.ElapsedTime)
 	s.GreaterOrEqual(queryResult.Status.RowsExamined, uint64(2))
@@ -223,7 +225,7 @@ func (s *EdgeTestSuite) TestEdgeIngestAndQueryRoundTrip() {
 		}
 		queryResult = res
 		return true
-	}, 30*time.Second, time.Second, "ingested events did not become queryable via edge")
+	}, 60*time.Second, time.Second, "ingested events did not become queryable via edge")
 
 	s.EqualValues(2, queryResult.Status.RowsMatched)
 }


### PR DESCRIPTION
The integration suites run against a live, eventually-consistent deployment, and a few tests asserted on freshly-ingested data (or shared a fixed dataset name), so they failed intermittently regardless of the change under test — most recently seen breaking unrelated dependabot PRs.

`TestIngestWithMapFields` queried immediately after ingest and asserted an exact field/column count, but the second event's flattened columns didn't always propagate in time (row counts were already correct, so only the schema lagged). It now polls with `Eventually` until the full schema is queryable before asserting.

The edge tests get two robustness tweaks: the ingest->query propagation wait goes from 30s to 60s to absorb slower propagation under load, and each test now uses a unique dataset name so a single transient teardown-delete failure can't cascade into `entity exists` errors for every subsequent test in the suite.

No production code changes; tests only.

Made with [Cursor](https://cursor.com)