### PR TITLE
{axiom,axiom/query}: add IsPartial and IsEstimate to the query status

### DIFF
--- a/axiom/datasets.go
+++ b/axiom/datasets.go
@@ -925,6 +925,8 @@ func setQueryStatusOnSpan(span trace.Span, status query.Status) {
 		attribute.String("axiom.query.elapsed_time", status.ElapsedTime.String()),
 		attribute.Int64("axiom.query.rows_examined", int64(status.RowsExamined)), //nolint:gosec // Fine for this use case.
 		attribute.Int64("axiom.query.rows_matched", int64(status.RowsMatched)),   //nolint:gosec // Fine for this use case.
+		attribute.Bool("axiom.query.is_partial", status.IsPartial),
+		attribute.Bool("axiom.query.is_estimate", status.IsEstimate),
 	)
 }
 

--- a/axiom/query/result.go
+++ b/axiom/query/result.go
@@ -136,6 +136,12 @@ type Status struct {
 	RowsExamined uint64 `json:"rowsExamined"`
 	// RowsMatched is the amount of rows that matched the query.
 	RowsMatched uint64 `json:"rowsMatched"`
+	// IsPartial describes if the query result is a partial result.
+	IsPartial bool `json:"isPartial"`
+	// IsEstimate describes if the query result is estimated. This is the case
+	// when the server trimmed intermediate results, for example a "top" over a
+	// high cardinality group.
+	IsEstimate bool `json:"isEstimate"`
 	// Messages is an optional list of messages that was emitted during query execution.
 	Messages []Message `json:"messages,omitempty"`
 }

--- a/axiom/query/result_test.go
+++ b/axiom/query/result_test.go
@@ -9,13 +9,42 @@ import (
 )
 
 func TestStatus_UnmarshalJSON(t *testing.T) {
-	exp := Status{
-		ElapsedTime: time.Second,
+	tests := []struct {
+		name  string
+		input string
+		exp   Status
+	}{
+		{
+			// The server sends the elapsed time in microseconds. This case also
+			// covers the result quality flags defaulting to false, which is how
+			// the server signals them: it omits "isEstimate" unless it is true.
+			name:  "elapsed time",
+			input: `{ "elapsedTime": 1000000 }`,
+			exp:   Status{ElapsedTime: time.Second},
+		},
+		{
+			name:  "estimate",
+			input: `{ "elapsedTime": 1000000, "isEstimate": true }`,
+			exp:   Status{ElapsedTime: time.Second, IsEstimate: true},
+		},
+		{
+			name:  "partial",
+			input: `{ "elapsedTime": 1000000, "isPartial": true }`,
+			exp:   Status{ElapsedTime: time.Second, IsPartial: true},
+		},
+		{
+			name:  "partial and estimate",
+			input: `{ "elapsedTime": 1000000, "isPartial": true, "isEstimate": true }`,
+			exp:   Status{ElapsedTime: time.Second, IsPartial: true, IsEstimate: true},
+		},
 	}
 
-	var act Status
-	err := act.UnmarshalJSON([]byte(`{ "elapsedTime": 1000000 }`))
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var act Status
+			require.NoError(t, act.UnmarshalJSON([]byte(tt.input)))
 
-	assert.Equal(t, exp, act)
+			assert.Equal(t, tt.exp, act)
+		})
+	}
 }


### PR DESCRIPTION
The server reports `isPartial` and `isEstimate` on the APL query status, but `query.Status` drops both. Callers cannot currently tell an estimated aggregate from an exact one.

This is reachable today. A `top` over a high cardinality group returns estimated counts, verified against staging:

```
['<dataset>'] | summarize count() by _sysTime | top 5 by count_
→ {"isEstimate": true}
```

`isEstimate` is sent with `omitempty`, so an absent field means false and a plain `bool` covers it. No `UnmarshalJSON` change is needed: it delegates to `json.Unmarshal` through a `localStatus` alias purely to fix up `ElapsedTime`, so the new fields decode for free.

Both flags are also recorded on the query span, matching the attributes `setLegacyQueryStatusOnSpan` already sets.

## Scope

`query.Status` exposes a curated subset of the server's status. This adds only the two flags that say whether you can trust the numbers, and leaves out the engine counters (`blocksExamined`, `blocksCached`, `numGroups`, `cacheStatus`, `minBlockTime`/`maxBlockTime`). `continuationToken` is also left out, since the modern APL path has no working resume flow to pair it with.

## One thing worth a second opinion

The server writes `isEstimate` from the default status encoder, which is what this SDK hits, and `isEstimated` from the v2 APL encoder, which is opt-in through a request format header the SDK never sends. The tag here is correct today. If axiom-go ever adopts the v2 format, this field silently reads false with no error. That naming split looks worth fixing server side rather than carrying both tags here.

## Testing

`TestStatus_UnmarshalJSON` became a table covering each flag alone, both together, and neither. It keeps the original full-struct comparison, so the no-flags case also proves nothing else gets populated by accident.

Verified end to end against staging by building the CLI against this branch with a local `replace`: the estimating query above prints an estimate warning, and a plain `limit` query stays silent.
