### PR TITLE
axiom: let LimitError be inspected as an HTTPError

### DIFF
--- a/axiom/error.go
+++ b/axiom/error.go
@@ -51,7 +51,10 @@ func (e HTTPError) Is(target error) bool {
 }
 
 // LimitError occurs when http status codes 429 (TooManyRequests) or 430
-// (Axiom-sepcific when ingest or query limit are reached) are encountered.
+// (Axiom-specific when ingest or query limit are reached) are encountered.
+//
+// It can be inspected as an [HTTPError] using [errors.As]. Code that handles
+// both must match LimitError first, as the [HTTPError] case matches it, too.
 type LimitError struct {
 	HTTPError
 
@@ -73,4 +76,15 @@ func (e LimitError) Is(target error) bool {
 		return false
 	}
 	return e.Limit == v.Limit && e.HTTPError.Is(v.HTTPError)
+}
+
+// As assigns the embedded [HTTPError] to target, so callers that handle any API
+// error the same way do not have to special case a limit error.
+func (e LimitError) As(target any) bool {
+	httpErr, ok := target.(*HTTPError)
+	if !ok {
+		return false
+	}
+	*httpErr = e.HTTPError
+	return true
 }

--- a/axiom/error_test.go
+++ b/axiom/error_test.go
@@ -1,10 +1,21 @@
 package axiom_test
 
 import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/axiomhq/axiom-go/axiom"
 )
 
-type is interface{ Is(error) bool }
+type (
+	is interface{ Is(error) bool }
+	as interface{ As(any) bool }
+)
 
 var (
 	_ error = (*axiom.HTTPError)(nil)
@@ -12,4 +23,66 @@ var (
 
 	_ is = (*axiom.HTTPError)(nil)
 	_ is = (*axiom.LimitError)(nil)
+
+	_ as = (*axiom.LimitError)(nil)
 )
+
+func TestLimitError_As(t *testing.T) {
+	httpErr := axiom.HTTPError{
+		Status:  http.StatusTooManyRequests,
+		Message: "Too Many Requests",
+		TraceID: "abc123",
+	}
+	limitErr := axiom.LimitError{HTTPError: httpErr}
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"direct", limitErr},
+		{"wrapped", fmt.Errorf("running query: %w", limitErr)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var act axiom.HTTPError
+			require.True(t, errors.As(tt.err, &act))
+
+			// The projection must carry every field, not just the type.
+			assert.Equal(t, httpErr, act)
+		})
+	}
+
+	t.Run("still matches its own type", func(t *testing.T) {
+		var act axiom.LimitError
+		require.True(t, errors.As(error(limitErr), &act))
+
+		assert.Equal(t, limitErr, act)
+	})
+}
+
+// The projection must not leak into equality. A limit error is not the same as
+// any other error that shares its status code. Adding an Unwrap method to
+// [axiom.LimitError] breaks this.
+func TestLimitError_Is(t *testing.T) {
+	limitErr := axiom.LimitError{
+		HTTPError: axiom.HTTPError{Status: http.StatusTooManyRequests},
+		Limit:     axiom.Limit{Remaining: 0},
+	}
+
+	assert.False(t, errors.Is(limitErr, axiom.HTTPError{Status: http.StatusTooManyRequests}))
+	assert.Nil(t, errors.Unwrap(limitErr))
+
+	for _, sentinel := range []error{
+		axiom.ErrUnauthorized,
+		axiom.ErrUnauthenticated,
+		axiom.ErrNotFound,
+		axiom.ErrExists,
+	} {
+		assert.False(t, errors.Is(limitErr, sentinel), "matched %v", sentinel)
+	}
+
+	other := limitErr
+	other.Limit.Remaining = 99
+	assert.False(t, errors.Is(limitErr, other))
+}


### PR DESCRIPTION
`errors.As` cannot project a `LimitError` onto the `HTTPError` it embeds, because embedding alone does not make the two types match. A caller that wants the status, message or trace id of any API error has to special case the limit case. The Axiom CLI carries exactly that workaround today, which is what prompted this.

## Why `As` and not `Unwrap`

`Unwrap` means "the error that caused this". `LimitError` embeds `HTTPError`, which is an is-a relationship, not a causal chain.

No standard library precedent unwraps an embedded base to make a specialization match it. `fs.PathError`, `os.SyscallError`, `url.Error`, `json.MarshalerError`, `csv.ParseError`, and `template.ExecError` all hold a distinct underlying `Err` instead.

`As` is the mechanism Go documents for this. It lets an error "be treated as if it were a different error type". It is also strictly narrower. The table below compares both against the real method sets:

| | custom `As` | `Unwrap` |
|---|---|---|
| `errors.As(limitErr, &httpErr)` | true, all fields intact | true |
| same, through a `%w` wrapper | true | true |
| `errors.As(limitErr, &limitErr)` | still true | still true |
| `errors.Is(limitErr, HTTPError{Status: 429})` | **false**, unchanged | **flips to true** |
| `errors.Unwrap(limitErr)` | **nil**, unchanged | **non-nil** |
| `errors.Is(limitErr, ErrNotFound)` and the other sentinels | false | false |

`Unwrap` changes equivalence semantics and the wrap chain on top of the projection. Only the projection is wanted here.

## Compatibility

Source compatible, nothing fails to compile. It is behaviorally breaking in one way that belongs in the release notes:

```go
switch {
case errors.As(err, &httpErr):   // a LimitError now lands here
case errors.As(err, &limitErr):  // and this becomes unreachable
}
```

A consumer that orders the generic case before the specific one loses its rate limit handling silently. That is inherent to making the two types match at all, so no implementation avoids it. The doc comment on `LimitError` now says to match it first.

Release this as a minor `v0.x` bump and call out the behavior change in the release notes.

## Testing

Tests cover `As` through a direct value and through a `%w` wrapper. Both assert the projection carries `Status`, `Message`, and `TraceID`, not just the matching type.

A separate test pins what must not change:

- `errors.Is` against an `HTTPError` of the same status stays false.
- `errors.Unwrap` stays nil.
- All four sentinels stay false.
- Two limit errors with different `Limit` values stay unequal.

Also fixes the `Axiom-sepcific` typo on the doc line being edited.
