### PR TITLE
.github/workflows: stop integration tests from leaking datasets

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -117,7 +117,7 @@ jobs:
       AXIOM_EDGE_URL: ${{ vars[format('TESTING_{0}_EDGE_URL', matrix.slug)] }}
       AXIOM_EDGE_TOKEN: ${{ secrets[format('TESTING_{0}_EDGE_TOKEN', matrix.slug)] }}
       AXIOM_EDGE_DEPLOYMENT: ${{ vars[format('TESTING_{0}_EDGE_DATASET_REGION', matrix.slug)] }}
-      AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ matrix.go }}
+      AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.go }}
       TELEMETRY_TRACES_URL: ${{ secrets.TELEMETRY_TRACES_URL }}
       TELEMETRY_TRACES_TOKEN: ${{ secrets.TELEMETRY_TRACES_TOKEN }}
       TELEMETRY_TRACES_DATASET: ${{ vars[format('TELEMETRY_{0}_TRACES_DATASET', matrix.slug)] }}
@@ -128,11 +128,11 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: Test
         run: make test-integration
-      - name: Cleanup (On Test Failure)
-        if: failure()
+      - name: Cleanup
+        if: failure() || cancelled()
         run: |
           curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.14.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
-          axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ matrix.go }}")).id' | xargs -r -n1 axiom dataset delete -f
+          axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.go }}")).id' | xargs -r -n1 axiom dataset delete -f
 
   ci-pass:
     name: CI Pass

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -81,7 +81,7 @@ jobs:
       AXIOM_EDGE_URL: ${{ vars[format('TESTING_{0}_EDGE_URL', matrix.slug)] }}
       AXIOM_EDGE_TOKEN: ${{ secrets[format('TESTING_{0}_EDGE_TOKEN', matrix.slug)] }}
       AXIOM_EDGE_DEPLOYMENT: ${{ vars[format('TESTING_{0}_EDGE_DATASET_REGION', matrix.slug)] }}
-      AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ matrix.go }}
+      AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.go }}
       TELEMETRY_TRACES_URL: ${{ secrets.TELEMETRY_TRACES_URL }}
       TELEMETRY_TRACES_TOKEN: ${{ secrets.TELEMETRY_TRACES_TOKEN }}
       TELEMETRY_TRACES_DATASET: ${{ vars[format('TELEMETRY_{0}_TRACES_DATASET', matrix.slug)] }}
@@ -91,8 +91,8 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: make test-integration
-      - name: Cleanup (On Test Failure)
-        if: failure()
+      - name: Cleanup
+        if: failure() || cancelled()
         run: |
           curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.14.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
-          axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ matrix.go }}")).id' | xargs -r -n1 axiom dataset delete -f
+          axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.go }}")).id' | xargs -r -n1 axiom dataset delete -f

--- a/.github/workflows/server_regression.yaml
+++ b/.github/workflows/server_regression.yaml
@@ -41,7 +41,7 @@ jobs:
       AXIOM_EDGE_URL: ${{ vars[format('TESTING_{0}_EDGE_URL', matrix.slug)] }}
       AXIOM_EDGE_TOKEN: ${{ secrets[format('TESTING_{0}_EDGE_TOKEN', matrix.slug)] }}
       AXIOM_EDGE_DEPLOYMENT: ${{ vars[format('TESTING_{0}_EDGE_DATASET_REGION', matrix.slug)] }}
-      AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ matrix.go }}
+      AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.go }}
       TELEMETRY_TRACES_URL: ${{ secrets.TELEMETRY_TRACES_URL }}
       TELEMETRY_TRACES_TOKEN: ${{ secrets.TELEMETRY_TRACES_TOKEN }}
       TELEMETRY_TRACES_DATASET: ${{ vars[format('TELEMETRY_{0}_TRACES_DATASET', matrix.slug)] }}
@@ -51,8 +51,8 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: make test-integration
-      - name: Cleanup (On Test Failure)
-        if: failure()
+      - name: Cleanup
+        if: failure() || cancelled()
         run: |
           curl -sL $(curl -s https://api.github.com/repos/axiomhq/cli/releases/tags/v0.14.0 | grep "http.*linux_amd64.tar.gz" | awk '{print $2}' | sed 's|[\"\,]*||g') | tar xzvf - --strip-components=1 --wildcards -C /usr/local/bin "axiom_*_linux_amd64/axiom"
-          axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ matrix.go }}")).id' | xargs -r -n1 axiom dataset delete -f
+          axiom dataset list -f=json | jq '.[] | select(.id | contains("${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.go }}")).id' | xargs -r -n1 axiom dataset delete -f

--- a/.github/workflows/test_examples.yaml
+++ b/.github/workflows/test_examples.yaml
@@ -87,7 +87,7 @@ jobs:
       AXIOM_URL: ${{ secrets.TESTING_STAGING_API_URL }}
       AXIOM_TOKEN: ${{ secrets.TESTING_STAGING_TOKEN }}
       AXIOM_ORG_ID: ${{ secrets.TESTING_STAGING_ORG_ID }}
-      AXIOM_DATASET: test-axiom-go-examples-${{ github.run_id }}-${{ matrix.example }}
+      AXIOM_DATASET: test-axiom-go-examples-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.example }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7


### PR DESCRIPTION
Two defects let the integration tests leave datasets behind, and then made the leak permanent. Both are in the same four workflows.

## The cleanup step does not run on cancellation

The step is guarded by `failure()`. That expression is false when a job is cancelled. Matrix fail-fast cancels the sibling jobs as soon as one of them fails, so a cancelled job skips its own teardown and the cleanup step. Its datasets stay on the deployment.

This is not theoretical. Two datasets from July sat on the dev integration testing org:

```
test-axiom-go-datasets-30594501545-1.25   2026-07-31
test-axiom-go-edge-29969963640-1.25       2026-07-23
```

The guard becomes `failure() || cancelled()`. The step name loses "(On Test Failure)", because it now covers both cases.

## A re-run reuses the leaked names

`AXIOM_DATASET_SUFFIX` is built from `run_id`, which is the same for every attempt of a run. Only `run_attempt` increments. A re-run of a job that leaked datasets tries to create the same names and fails with `API error 409: entity exists`.

The effect is that re-running a failed integration job can never reach green. I hit this on axiomhq/axiom-go#457: a flaky test cancelled a sibling job, and `gh run rerun --failed` then failed on the leftovers rather than on anything real.

`run_attempt` joins the suffix, so each attempt gets its own dataset names.

## Scope

`pr.yaml`, `push.yaml` and `server_regression.yaml` need both fixes. The suffix appears twice in each: once as the environment variable, and once in the `jq` filter of the cleanup step. They have to match, so both change together.

`test_examples.yaml` already deletes its dataset with `if: always()`, which is the pattern the other three now approach. It only needs the suffix.

## Testing

There is no way to test a workflow change before it is on the default branch. The YAML parses, and the CI run on this PR exercises the new suffix. The cancellation path shows up the next time fail-fast cancels a job.
