### PR TITLE
all: raise the minimum Go version to 1.27

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.26"
           - "1.27"
+          - "1.28"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -38,8 +38,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.26"
           - "1.27"
+          - "1.28"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -65,8 +65,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - "1.26"
           - "1.27"
+          - "1.28"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -100,8 +100,8 @@ jobs:
       fail-fast: true
       matrix:
         go:
-          - "1.26"
           - "1.27"
+          - "1.28"
         environment:
           - development
           - staging

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.26"
           - "1.27"
+          - "1.28"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -35,8 +35,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.26"
           - "1.27"
+          - "1.28"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -64,8 +64,8 @@ jobs:
       fail-fast: true
       matrix:
         go:
-          - "1.26"
           - "1.27"
+          - "1.28"
         environment:
           - development
           - staging

--- a/.github/workflows/server_regression.yaml
+++ b/.github/workflows/server_regression.yaml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.26"
           - "1.27"
+          - "1.28"
         environment:
           - development
           - staging

--- a/adapters/zerolog/zerolog_test.go
+++ b/adapters/zerolog/zerolog_test.go
@@ -114,8 +114,7 @@ func TestHook_FlushFullBatch(t *testing.T) {
 		assert.EqualValues(t, 10_000, lines.Load())
 
 		// Advance virtual clock past the flush interval to trigger timer-based flush.
-		time.Sleep(flushInterval + time.Millisecond)
-		synctest.Wait()
+		synctest.Sleep(flushInterval + time.Millisecond)
 
 		assert.EqualValues(t, 10_001, lines.Load())
 	})

--- a/axiom/client_test.go
+++ b/axiom/client_test.go
@@ -588,11 +588,9 @@ func TestClient_Do_RateLimit(t *testing.T) {
 	reset := time.Now().Add(time.Hour).Truncate(time.Second)
 
 	expErr := LimitError{
-		HTTPError: HTTPError{
-			Status:  http.StatusTooManyRequests,
-			Message: "limit exceeded",
-			TraceID: "abc",
-		},
+		Status:  http.StatusTooManyRequests,
+		Message: "limit exceeded",
+		TraceID: "abc",
 
 		Limit: Limit{
 			Scope:     LimitScopeAnonymous,

--- a/axiom/dashboards_integration_test.go
+++ b/axiom/dashboards_integration_test.go
@@ -155,16 +155,14 @@ func (s *DashboardsTestSuite) TestAllChartTypes() {
 	uid := fmt.Sprintf("dash-all-charts-%d", time.Now().UnixNano())
 
 	monitor, err := s.client.Monitors.Create(s.ctx, axiom.MonitorCreateRequest{
-		Monitor: axiom.Monitor{
-			Name:        "test-dashboard-monitor",
-			Description: "Monitor used by dashboards integration test",
-			Type:        axiom.MonitorTypeThreshold,
-			APLQuery:    fmt.Sprintf("['%s'] | summarize count()", s.dataset.ID),
-			Operator:    axiom.Above,
-			Threshold:   0,
-			Interval:    time.Minute,
-			Range:       time.Minute,
-		},
+		Name:        "test-dashboard-monitor",
+		Description: "Monitor used by dashboards integration test",
+		Type:        axiom.MonitorTypeThreshold,
+		APLQuery:    fmt.Sprintf("['%s'] | summarize count()", s.dataset.ID),
+		Operator:    axiom.Above,
+		Threshold:   0,
+		Interval:    time.Minute,
+		Range:       time.Minute,
 	})
 	s.Require().NoError(err)
 	s.monitor = monitor

--- a/axiom/error_test.go
+++ b/axiom/error_test.go
@@ -66,8 +66,8 @@ func TestLimitError_As(t *testing.T) {
 // [axiom.LimitError] breaks this.
 func TestLimitError_Is(t *testing.T) {
 	limitErr := axiom.LimitError{
-		HTTPError: axiom.HTTPError{Status: http.StatusTooManyRequests},
-		Limit:     axiom.Limit{Remaining: 0},
+		Status: http.StatusTooManyRequests,
+		Limit:  axiom.Limit{Remaining: 0},
 	}
 
 	assert.False(t, errors.Is(limitErr, axiom.HTTPError{Status: http.StatusTooManyRequests}))

--- a/axiom/monitors_integration_test.go
+++ b/axiom/monitors_integration_test.go
@@ -60,21 +60,19 @@ func (s *MonitorsTestSuite) SetupTest() {
 
 	var err error
 	s.monitor, err = s.client.Monitors.Create(s.ctx, axiom.MonitorCreateRequest{
-		Monitor: axiom.Monitor{
-			AlertOnNoData:                false,
-			APLQuery:                     fmt.Sprintf("['%s'] | summarize count()", s.datasetID),
-			Description:                  "A test monitor",
-			Interval:                     time.Minute,
-			Name:                         "Test Monitor",
-			Operator:                     axiom.BelowOrEqual,
-			Range:                        time.Minute * 5,
-			Threshold:                    1,
-			Delay:                        time.Second * 10,
-			NotifyEveryRun:               true,
-			SkipResolved:                 false,
-			TriggerFromNRuns:             3,
-			TriggerAfterNPositiveResults: 2,
-		},
+		AlertOnNoData:                false,
+		APLQuery:                     fmt.Sprintf("['%s'] | summarize count()", s.datasetID),
+		Description:                  "A test monitor",
+		Interval:                     time.Minute,
+		Name:                         "Test Monitor",
+		Operator:                     axiom.BelowOrEqual,
+		Range:                        time.Minute * 5,
+		Threshold:                    1,
+		Delay:                        time.Second * 10,
+		NotifyEveryRun:               true,
+		SkipResolved:                 false,
+		TriggerFromNRuns:             3,
+		TriggerAfterNPositiveResults: 2,
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(s.monitor)
@@ -98,17 +96,15 @@ func (s *MonitorsTestSuite) TearDownTest() {
 func (s *MonitorsTestSuite) Test() {
 	// Let's update the monitor.
 	monitor, err := s.client.Monitors.Update(s.ctx, s.monitor.ID, axiom.MonitorUpdateRequest{
-		Monitor: axiom.Monitor{
-			AlertOnNoData: false,
-			APLQuery:      fmt.Sprintf("['%s'] | summarize count()", s.datasetID),
-			Description:   "A very good test monitor",
-			DisabledUntil: time.Now().Add(time.Minute * 10),
-			Interval:      time.Minute,
-			Name:          "Test Monitor",
-			Operator:      axiom.BelowOrEqual,
-			Range:         time.Minute * 10,
-			Threshold:     5,
-		},
+		AlertOnNoData: false,
+		APLQuery:      fmt.Sprintf("['%s'] | summarize count()", s.datasetID),
+		Description:   "A very good test monitor",
+		DisabledUntil: time.Now().Add(time.Minute * 10),
+		Interval:      time.Minute,
+		Name:          "Test Monitor",
+		Operator:      axiom.BelowOrEqual,
+		Range:         time.Minute * 10,
+		Threshold:     5,
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(monitor)
@@ -133,18 +129,16 @@ func (s *MonitorsTestSuite) Test() {
 func (s *MonitorsTestSuite) TestCreateMatchMonitor() {
 	// Create the monitor
 	monitor, err := s.client.Monitors.Create(s.ctx, axiom.MonitorCreateRequest{
-		Monitor: axiom.Monitor{
-			AlertOnNoData: false,
-			APLQuery:      fmt.Sprintf("['%s']", s.datasetID),
-			Description:   "A very good test monitor",
-			DisabledUntil: time.Now().Add(time.Minute * 10),
-			Interval:      time.Minute,
-			Name:          "Test Monitor",
-			Operator:      axiom.BelowOrEqual,
-			Range:         time.Minute * 10,
-			Threshold:     5,
-			Type:          axiom.MonitorTypeMatchEvent,
-		},
+		AlertOnNoData: false,
+		APLQuery:      fmt.Sprintf("['%s']", s.datasetID),
+		Description:   "A very good test monitor",
+		DisabledUntil: time.Now().Add(time.Minute * 10),
+		Interval:      time.Minute,
+		Name:          "Test Monitor",
+		Operator:      axiom.BelowOrEqual,
+		Range:         time.Minute * 10,
+		Threshold:     5,
+		Type:          axiom.MonitorTypeMatchEvent,
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(monitor)
@@ -185,18 +179,16 @@ func (s *MonitorsTestSuite) TestCreateMatchMonitor() {
 func (s *MonitorsTestSuite) TestCreateAnomalyDetectionMonitor() {
 	// Create the monitor
 	monitor, err := s.client.Monitors.Create(s.ctx, axiom.MonitorCreateRequest{
-		Monitor: axiom.Monitor{
-			AlertOnNoData: false,
-			APLQuery:      fmt.Sprintf("['%s'] | summarize count() by bin_auto(_time)", s.datasetID),
-			Description:   "A very good test monitor",
-			Interval:      time.Minute,
-			Name:          "Test Monitor",
-			Operator:      axiom.Below,
-			Range:         time.Minute * 10,
-			Tolerance:     5,
-			CompareDays:   7,
-			Type:          axiom.MonitorTypeAnomalyDetection,
-		},
+		AlertOnNoData: false,
+		APLQuery:      fmt.Sprintf("['%s'] | summarize count() by bin_auto(_time)", s.datasetID),
+		Description:   "A very good test monitor",
+		Interval:      time.Minute,
+		Name:          "Test Monitor",
+		Operator:      axiom.Below,
+		Range:         time.Minute * 10,
+		Tolerance:     5,
+		CompareDays:   7,
+		Type:          axiom.MonitorTypeAnomalyDetection,
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(monitor)
@@ -206,16 +198,14 @@ func (s *MonitorsTestSuite) TestCreateAnomalyDetectionMonitor() {
 func (s *MonitorsTestSuite) TestCreateMonitorWithMPLQuery() {
 	expectedQuery := fmt.Sprintf("`%s`:`my-metric` | align to 5s using avg", s.datasetID)
 	monitor, err := s.client.Monitors.Create(s.ctx, axiom.MonitorCreateRequest{
-		Monitor: axiom.Monitor{
-			AlertOnNoData: false,
-			MPLQuery:      expectedQuery,
-			Description:   "A test monitor using mplQuery",
-			Interval:      time.Minute,
-			Name:          "Test MPL Monitor",
-			Operator:      axiom.BelowOrEqual,
-			Range:         time.Minute * 5,
-			Threshold:     1,
-		},
+		AlertOnNoData: false,
+		MPLQuery:      expectedQuery,
+		Description:   "A test monitor using mplQuery",
+		Interval:      time.Minute,
+		Name:          "Test MPL Monitor",
+		Operator:      axiom.BelowOrEqual,
+		Range:         time.Minute * 5,
+		Threshold:     1,
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(monitor)
@@ -241,15 +231,13 @@ func (s *MonitorsTestSuite) TestCreateMonitorWithMPLQuery() {
 
 func (s *MonitorsTestSuite) TestMonitorQueryExclusivityValidation() {
 	_, err := s.client.Monitors.Create(s.ctx, axiom.MonitorCreateRequest{
-		Monitor: axiom.Monitor{
-			APLQuery:  fmt.Sprintf("['%s'] | summarize count()", s.datasetID),
-			MPLQuery:  fmt.Sprintf("`%s`:`my-metric` | align to 5s using avg", s.datasetID),
-			Interval:  time.Minute,
-			Name:      "Invalid Dual Query Monitor",
-			Operator:  axiom.BelowOrEqual,
-			Range:     time.Minute * 5,
-			Threshold: 1,
-		},
+		APLQuery:  fmt.Sprintf("['%s'] | summarize count()", s.datasetID),
+		MPLQuery:  fmt.Sprintf("`%s`:`my-metric` | align to 5s using avg", s.datasetID),
+		Interval:  time.Minute,
+		Name:      "Invalid Dual Query Monitor",
+		Operator:  axiom.BelowOrEqual,
+		Range:     time.Minute * 5,
+		Threshold: 1,
 	})
 	s.Require().EqualError(err, "aplQuery and mplQuery are mutually exclusive, provide only one")
 }

--- a/axiom/tokens_test.go
+++ b/axiom/tokens_test.go
@@ -124,19 +124,18 @@ func TestTokensService_Get(t *testing.T) {
 func TestTokensService_Create(t *testing.T) {
 	tokenTime := testhelper.MustTimeParse(t, time.RFC3339, "2024-04-19T17:55:53Z")
 	exp := &CreateTokenResponse{
-		APIToken: APIToken{
-			Name:        "test",
-			Description: "test",
-			ExpiresAt:   tokenTime.UTC().Truncate(time.Second),
-			DatasetCapabilities: map[string]DatasetCapabilities{
-				"dataset": {
-					Ingest: []Action{ActionCreate},
-					Query:  []Action{ActionRead},
-				},
+		Name:        "test",
+		Description: "test",
+		ExpiresAt:   tokenTime.UTC().Truncate(time.Second),
+		DatasetCapabilities: map[string]DatasetCapabilities{
+			"dataset": {
+				Ingest: []Action{ActionCreate},
+				Query:  []Action{ActionRead},
 			},
-			OrganisationCapabilities: OrganisationCapabilities{
-				APITokens: []Action{ActionCreate},
-			}},
+		},
+		OrganisationCapabilities: OrganisationCapabilities{
+			APITokens: []Action{ActionCreate},
+		},
 		Token: "test",
 	}
 	hf := func(w http.ResponseWriter, r *http.Request) {
@@ -195,19 +194,17 @@ func TestTokensService_Regenerate(t *testing.T) {
 		NewTokenExpiresAt:      tokenTime.Add(time.Hour * 24),
 	}
 	exp := &CreateTokenResponse{
-		APIToken: APIToken{
-			Name:        "test",
-			Description: "test",
-			ExpiresAt:   tokenTime.Add(time.Hour * 24).UTC().Truncate(time.Second),
-			DatasetCapabilities: map[string]DatasetCapabilities{
-				"dataset": {
-					Ingest: []Action{ActionCreate},
-					Query:  []Action{ActionRead},
-				},
+		Name:        "test",
+		Description: "test",
+		ExpiresAt:   tokenTime.Add(time.Hour * 24).UTC().Truncate(time.Second),
+		DatasetCapabilities: map[string]DatasetCapabilities{
+			"dataset": {
+				Ingest: []Action{ActionCreate},
+				Query:  []Action{ActionRead},
 			},
-			OrganisationCapabilities: OrganisationCapabilities{
-				APITokens: []Action{ActionCreate},
-			},
+		},
+		OrganisationCapabilities: OrganisationCapabilities{
+			APITokens: []Action{ActionCreate},
 		},
 		Token: "test",
 	}
@@ -274,18 +271,16 @@ func TestTokensService_RegenerateWithNewToken(t *testing.T) {
 	}
 
 	exp := &CreateTokenResponse{
-		APIToken: APIToken{
-			Name:        "replacement",
-			Description: "replacement token",
-			ExpiresAt:   tokenTime.Add(48 * time.Hour).UTC().Truncate(time.Second),
-			DatasetCapabilities: map[string]DatasetCapabilities{
-				"dataset": {
-					Ingest: []Action{ActionCreate},
-				},
+		Name:        "replacement",
+		Description: "replacement token",
+		ExpiresAt:   tokenTime.Add(48 * time.Hour).UTC().Truncate(time.Second),
+		DatasetCapabilities: map[string]DatasetCapabilities{
+			"dataset": {
+				Ingest: []Action{ActionCreate},
 			},
-			OrganisationCapabilities: OrganisationCapabilities{
-				APITokens: []Action{ActionCreate},
-			},
+		},
+		OrganisationCapabilities: OrganisationCapabilities{
+			APITokens: []Action{ActionCreate},
 		},
 		Token: "replacement-token",
 	}

--- a/axiom/vfields_test.go
+++ b/axiom/vfields_test.go
@@ -12,13 +12,11 @@ import (
 func TestVirtualFieldsService_List(t *testing.T) {
 	exp := []*VirtualFieldWithID{
 		{
-			ID: "vfield1",
-			VirtualField: VirtualField{
-				Dataset:    "dataset1",
-				Name:       "field1",
-				Expression: "a + b",
-				Type:       "number",
-			},
+			ID:         "vfield1",
+			Dataset:    "dataset1",
+			Name:       "field1",
+			Expression: "a + b",
+			Type:       "number",
 		},
 	}
 
@@ -46,13 +44,11 @@ func TestVirtualFieldsService_List(t *testing.T) {
 
 func TestVirtualFieldsService_Get(t *testing.T) {
 	exp := &VirtualFieldWithID{
-		ID: "vfield1",
-		VirtualField: VirtualField{
-			Dataset:    "dataset1",
-			Name:       "field1",
-			Expression: "a + b",
-			Type:       "number",
-		},
+		ID:         "vfield1",
+		Dataset:    "dataset1",
+		Name:       "field1",
+		Expression: "a + b",
+		Type:       "number",
 	}
 
 	hf := func(w http.ResponseWriter, r *http.Request) {
@@ -78,13 +74,11 @@ func TestVirtualFieldsService_Get(t *testing.T) {
 
 func TestVirtualFieldsService_Create(t *testing.T) {
 	exp := &VirtualFieldWithID{
-		ID: "vfield1",
-		VirtualField: VirtualField{
-			Dataset:    "dataset1",
-			Name:       "field1",
-			Expression: "a + b",
-			Type:       "number",
-		},
+		ID:         "vfield1",
+		Dataset:    "dataset1",
+		Name:       "field1",
+		Expression: "a + b",
+		Type:       "number",
 	}
 	hf := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
@@ -115,13 +109,11 @@ func TestVirtualFieldsService_Create(t *testing.T) {
 
 func TestVirtualFieldsService_Update(t *testing.T) {
 	exp := &VirtualFieldWithID{
-		ID: "vfield1",
-		VirtualField: VirtualField{
-			Dataset:    "dataset1",
-			Name:       "field1_updated",
-			Expression: "a - b",
-			Type:       "number",
-		},
+		ID:         "vfield1",
+		Dataset:    "dataset1",
+		Name:       "field1_updated",
+		Expression: "a - b",
+		Type:       "number",
 	}
 	hf := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/axiomhq/axiom-go
 
-go 1.26.0
+go 1.27.0
 
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
@@ -10,9 +10,11 @@ tool (
 
 require (
 	github.com/apex/log v1.9.0
+	github.com/buger/jsonparser v1.6.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/google/go-querystring v1.2.0
 	github.com/klauspost/compress v1.19.2
+	github.com/rs/zerolog v1.35.1
 	github.com/schollz/progressbar/v3 v3.19.1
 	github.com/sirupsen/logrus v1.10.1
 	github.com/stretchr/testify v1.12.1
@@ -28,67 +30,44 @@ require (
 )
 
 require (
+	4d63.com/gocheckcompilerdirectives v1.4.0 // indirect
+	4d63.com/gochecknoglobals v0.2.2 // indirect
 	charm.land/lipgloss/v2 v2.0.6 // indirect
 	codeberg.org/chavacava/garif v0.2.0 // indirect
 	codeberg.org/polyfloyd/go-errorlint v1.9.0 // indirect
 	dev.gaijin.team/go/exhaustruct/v4 v4.0.0 // indirect
 	dev.gaijin.team/go/exhaustruct/v5 v5.0.3 // indirect
 	dev.gaijin.team/go/golib v0.8.1 // indirect
-	github.com/AdminBenni/iota-mixing v1.0.0 // indirect
-	github.com/AlwxSin/noinlineerr v1.0.6 // indirect
-	github.com/ClickHouse/clickhouse-go-linter v1.2.1 // indirect
-	github.com/MirrexOne/unqueryvet v1.5.4 // indirect
-	github.com/alfatraining/structtag v1.0.0 // indirect
-	github.com/ashanbrown/forbidigo/v2 v2.3.1 // indirect
-	github.com/ashanbrown/makezero/v2 v2.2.1 // indirect
-	github.com/bombsimon/wsl/v5 v5.8.0 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886 // indirect
-	github.com/charmbracelet/x/termios v0.1.1 // indirect
-	github.com/charmbracelet/x/windows v0.2.2 // indirect
-	github.com/clipperhouse/displaywidth v0.11.0 // indirect
-	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
-	github.com/dlclark/regexp2/v2 v2.2.1 // indirect
-	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
-	github.com/golangci/asciicheck v0.5.0 // indirect
-	github.com/golangci/golangci-lint/v2 v2.13.0 // indirect
-	github.com/golangci/rowserrcheck v0.0.0-20260419091836-c5f79b8a11ba // indirect
-	github.com/golangci/swaggoswag v0.0.0-20250504205917-77f2aca3143e // indirect
-	github.com/ldez/structtags v0.6.1 // indirect
-	github.com/manuelarte/embeddedstructfieldcheck v0.4.0 // indirect
-	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/ryancurrah/gomodguard/v2 v2.1.3 // indirect
-	go.augendre.info/arangolint v0.4.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/tools v0.49.0 // indirect
-	gotest.tools/gotestsum v1.13.0 // indirect
-)
-
-require (
-	4d63.com/gocheckcompilerdirectives v1.4.0 // indirect
-	4d63.com/gochecknoglobals v0.2.2 // indirect
 	github.com/4meepo/tagalign v1.4.3 // indirect
 	github.com/Abirdcfly/dupword v0.1.8 // indirect
+	github.com/AdminBenni/iota-mixing v1.0.0 // indirect
+	github.com/AlwxSin/noinlineerr v1.0.6 // indirect
 	github.com/Antonboom/errname v1.1.2 // indirect
 	github.com/Antonboom/nilnil v1.1.2 // indirect
 	github.com/Antonboom/testifylint v1.6.4 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
+	github.com/ClickHouse/clickhouse-go-linter v1.2.1 // indirect
 	github.com/Djarvur/go-err113 v0.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
+	github.com/MirrexOne/unqueryvet v1.5.4 // indirect
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.1 // indirect
 	github.com/alecthomas/chroma/v2 v2.27.0 // indirect
 	github.com/alecthomas/go-check-sumtype v0.3.1 // indirect
 	github.com/alexkohler/nakedret/v2 v2.0.6 // indirect
 	github.com/alexkohler/prealloc v1.1.0 // indirect
+	github.com/alfatraining/structtag v1.0.0 // indirect
 	github.com/alingse/asasalint v0.0.11 // indirect
 	github.com/alingse/nilnesserr v0.2.0 // indirect
+	github.com/ashanbrown/forbidigo/v2 v2.3.1 // indirect
+	github.com/ashanbrown/makezero/v2 v2.2.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect
+	github.com/bombsimon/wsl/v5 v5.8.0 // indirect
 	github.com/breml/bidichk v0.3.3 // indirect
 	github.com/breml/errchkjson v0.4.1 // indirect
-	github.com/buger/jsonparser v1.6.1
 	github.com/butuzov/ireturn v0.4.1 // indirect
 	github.com/butuzov/mirror v1.3.3 // indirect
 	github.com/catenacyber/perfsprint v0.10.1 // indirect
@@ -97,13 +76,19 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charithe/durationcheck v0.0.11 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886 // indirect
 	github.com/charmbracelet/x/ansi v0.11.8 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
+	github.com/charmbracelet/x/termios v0.1.1 // indirect
+	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/ckaznocha/intrange v0.3.1 // indirect
+	github.com/clipperhouse/displaywidth v0.11.0 // indirect
+	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/daixiang0/gci v0.13.7 // indirect
 	github.com/dave/dst v0.27.3 // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
+	github.com/dlclark/regexp2/v2 v2.2.1 // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/color v1.19.0 // indirect
@@ -126,15 +111,20 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/golangci/asciicheck v0.5.0 // indirect
 	github.com/golangci/dupl v0.0.0-20260401084720-c99c5cf5c202 // indirect
 	github.com/golangci/go-printf-func-name v0.1.1 // indirect
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d // indirect
+	github.com/golangci/golangci-lint/v2 v2.13.0 // indirect
 	github.com/golangci/golines v0.15.0 // indirect
 	github.com/golangci/misspell v0.8.0 // indirect
 	github.com/golangci/plugin-module-register v0.1.2 // indirect
 	github.com/golangci/revgrep v0.8.0 // indirect
+	github.com/golangci/rowserrcheck v0.0.0-20260419091836-c5f79b8a11ba // indirect
+	github.com/golangci/swaggoswag v0.0.0-20250504205917-77f2aca3143e // indirect
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
@@ -163,12 +153,14 @@ require (
 	github.com/ldez/exptostd v0.4.5 // indirect
 	github.com/ldez/gomoddirectives v0.9.0 // indirect
 	github.com/ldez/grignotin v0.10.1 // indirect
+	github.com/ldez/structtags v0.6.1 // indirect
 	github.com/ldez/tagliatelle v0.7.2 // indirect
 	github.com/ldez/usetesting v0.5.0 // indirect
 	github.com/leonklingele/grouper v1.1.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.1 // indirect
 	github.com/macabu/inamedparam v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
+	github.com/manuelarte/embeddedstructfieldcheck v0.4.0 // indirect
 	github.com/manuelarte/funcorder v0.6.0 // indirect
 	github.com/maratori/testableexamples v1.0.1 // indirect
 	github.com/maratori/testpackage v1.1.2 // indirect
@@ -182,6 +174,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moricho/tparallel v0.3.2 // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
@@ -201,8 +194,8 @@ require (
 	github.com/raeperd/recvcheck v0.3.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.16.0 // indirect
-	github.com/rs/zerolog v1.35.1
 	github.com/ryancurrah/gomodguard v1.4.1 // indirect
+	github.com/ryancurrah/gomodguard/v2 v2.1.3 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.6.0 // indirect
 	github.com/sanposhiho/wastedassign/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 // indirect
@@ -242,17 +235,20 @@ require (
 	gitlab.com/bosi/decorder v0.4.2 // indirect
 	go-simpler.org/musttag v0.14.0 // indirect
 	go-simpler.org/sloglint v0.12.0 // indirect
+	go.augendre.info/arangolint v0.4.0 // indirect
 	go.augendre.info/fatcontext v0.10.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260718201538-764159d718ef // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
+	golang.org/x/tools v0.49.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/grpc v1.83.0 // indirect
@@ -260,6 +256,7 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools/gotestsum v1.13.0 // indirect
 	honnef.co/go/tools v0.8.0-rc.1 // indirect
 	mvdan.cc/gofumpt v0.11.0 // indirect
 	mvdan.cc/unparam v0.0.0-20260818115549-3f964bcb5673 // indirect


### PR DESCRIPTION
Raises the minimum Go version to 1.27. Draft until Go 1.28 ships.

## Do not merge before Go 1.28

axiom-go supports the latest two Go versions, 1.26 and 1.27. A `go 1.27` directive drops 1.26 users and leaves one. Go 1.28 restores the second.

CI is red for the same reason. `actions/setup-go` cannot resolve a bare `"1.28"` before the stable release. Re-run CI on release day.

## Changes

`go.mod` moves to `go 1.27.0`, and all eight CI matrices move to 1.27/1.28.

Go 1.27 struct literal keys accept any field selector, so the embedded wrapper drops out across six test files. This is most of the diff. `modernize` flags it once `go.mod` declares 1.27, so `make lint` fails without it.

```go
-axiom.MonitorCreateRequest{Monitor: axiom.Monitor{Name: "Test Monitor"}}
+axiom.MonitorCreateRequest{Name: "Test Monitor"}
```

`go mod tidy` now writes two require blocks. That moved `buger/jsonparser` and `rs/zerolog` back to the direct block. No version changed.

`adapters/zerolog/zerolog_test.go` uses `synctest.Sleep`, which is `time.Sleep` plus `synctest.Wait`. The `time.Sleep` calls in `axiom/datasets_test.go` have no `Wait` after them and stay.

`encoding/json/v2` is out of scope. It is the largest 1.27 item and needs its own change.
